### PR TITLE
build: no bundle wasm

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,29 +1,6 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
-import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
-	plugins: [
-		sveltekit(),
-		viteStaticCopy({
-			targets: [
-				{
-					src: 'node_modules/@ricky0123/vad-web/dist/vad.worklet.bundle.min.js',
-					dest: './'
-				},
-				{
-					src: 'node_modules/@ricky0123/vad-web/dist/silero_vad_v5.onnx',
-					dest: './'
-				},
-				{
-					src: 'node_modules/onnxruntime-web/dist/*.wasm',
-					dest: './'
-				},
-				{
-					src: 'node_modules/onnxruntime-web/dist/ort-wasm-simd-threaded.mjs',
-					dest: './'
-				}
-			]
-		})
-	]
+	plugins: [sveltekit()]
 });


### PR DESCRIPTION
This pull request involves a significant change to the `vite.config.ts` file, specifically the removal of the `vite-plugin-static-copy` plugin and its associated configurations.

### Removal of unnecessary plugin and configurations:

* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL3-R5): Removed the `viteStaticCopy` plugin and its configuration for copying various files from `node_modules` to the destination directory. The `plugins` array now only includes `sveltekit()`.