### PR TITLE
Feat/group stage history

### DIFF
--- a/src/lib/components/session/EndedView.svelte
+++ b/src/lib/components/session/EndedView.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+	import type { Conversation } from '$lib/schema/conversation';
+	import type { Group } from '$lib/schema/group';
+	import Summary from './Summary.svelte';
+	import GroupSummary from './GroupSummary.svelte';
+	import Chatroom from '$lib/components/Chatroom.svelte';
+
+	let { conversationDoc, groupDoc, user } = $props<{
+		conversationDoc: { data: Conversation; id: string } | null;
+		groupDoc: { data: Group; id: string } | null;
+		user: { uid: string };
+	}>();
+
+	let activeTab = $state('summary'); // 'summary', 'groupSummary', 'chat', 'groupChat'
+
+	let individualConversations = $derived.by(() => {
+		if (!conversationDoc) return [];
+		return conversationDoc.data.history.map(
+			(message: { role: string; content: string; audio?: string }) => ({
+				name: message.role === 'user' ? 'You' : 'AI Assistant',
+				content: message.content,
+				self: message.role === 'user',
+				audio: message.audio || undefined
+			})
+		);
+	});
+
+	let groupConversations = $derived.by(() => {
+		if (!groupDoc) return [];
+		return groupDoc.data.discussions.map(
+			(discussion: {
+				speaker: string;
+				content: string;
+				id: string | null;
+				audio: string | null;
+			}) => ({
+				name: discussion.speaker,
+				content: discussion.content,
+				self: discussion.id === user.uid,
+				audio: discussion.audio || undefined
+			})
+		);
+	});
+</script>
+
+<div class="space-y-4">
+	<div class="flex space-x-4">
+		<button
+			class="rounded-lg px-4 py-2 {activeTab === 'summary'
+				? 'bg-blue-500 text-white'
+				: 'bg-gray-200'}"
+			onclick={() => (activeTab = 'summary')}
+		>
+			個人總結
+		</button>
+		<button
+			class="rounded-lg px-4 py-2 {activeTab === 'groupSummary'
+				? 'bg-blue-500 text-white'
+				: 'bg-gray-200'}"
+			onclick={() => (activeTab = 'groupSummary')}
+		>
+			群組總結
+		</button>
+		<button
+			class="rounded-lg px-4 py-2 {activeTab === 'chat' ? 'bg-blue-500 text-white' : 'bg-gray-200'}"
+			onclick={() => (activeTab = 'chat')}
+		>
+			個人對話歷史
+		</button>
+		<button
+			class="rounded-lg px-4 py-2 {activeTab === 'groupChat'
+				? 'bg-blue-500 text-white'
+				: 'bg-gray-200'}"
+			onclick={() => (activeTab = 'groupChat')}
+		>
+			群組討論歷史
+		</button>
+	</div>
+
+	{#if activeTab === 'summary' && conversationDoc}
+		<Summary
+			conversation={conversationDoc}
+			loading={false}
+			readonly={true}
+			onRefresh={async () => {}}
+		/>
+	{:else if activeTab === 'groupSummary' && groupDoc}
+		<GroupSummary
+			group={{
+				data: groupDoc.data,
+				id: groupDoc.id
+			}}
+			loading={false}
+			readonly={true}
+			onRefresh={async () => {}}
+			onUpdate={async () => {}}
+		/>
+	{:else if activeTab === 'chat' && conversationDoc}
+		<div class="h-[600px] rounded-lg border bg-white p-4">
+			<Chatroom conversations={individualConversations} readonly={true} />
+		</div>
+	{:else if activeTab === 'groupChat' && groupDoc}
+		<div class="h-[600px] rounded-lg border bg-white p-4">
+			<Chatroom conversations={groupConversations} readonly={true} />
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/session/GroupChatHistory.svelte
+++ b/src/lib/components/session/GroupChatHistory.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { Modal, TabItem, Tabs } from 'flowbite-svelte';
+	import Chatroom from '$lib/components/Chatroom.svelte';
+	import GroupSummary from './GroupSummary.svelte';
+	import type { Group } from '$lib/schema/group';
+
+	let {
+		open = $bindable(false),
+		group = null,
+		readonly = true
+	} = $props<{
+		open: boolean;
+		group: {
+			data: Group;
+			id: string;
+			discussions: Array<{
+				name: string;
+				content: string;
+				self?: boolean;
+				audio?: string;
+				avatar?: string;
+			}>;
+		} | null;
+		readonly?: boolean;
+	}>();
+
+	let loadingGroupSummary = $state(false);
+</script>
+
+{#if open && group}
+	<Modal bind:open size="xl" outsideclose class="w-full">
+		<div class="mb-4">
+			<h3 class="text-xl font-semibold">
+				第 {group.data.number} 組的討論記錄
+			</h3>
+		</div>
+
+		<Tabs style="underline">
+			<TabItem open title="討論歷史">
+				<div class="messages h-[400px] overflow-y-auto rounded-lg border border-gray-200 p-4">
+					<Chatroom readonly conversations={group.discussions} />
+				</div>
+			</TabItem>
+			<TabItem title="討論總結">
+				<div class="h-[400px] overflow-y-auto rounded-lg border border-gray-200 p-4">
+					<GroupSummary
+						{group}
+						loading={loadingGroupSummary}
+						onRefresh={() => Promise.resolve()}
+						onUpdate={() => Promise.resolve()}
+						{readonly}
+					/>
+				</div>
+			</TabItem>
+		</Tabs>
+	</Modal>
+{/if}

--- a/src/lib/components/session/GroupStatus.svelte
+++ b/src/lib/components/session/GroupStatus.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { Timestamp } from 'firebase/firestore';
+
+	let { group } = $props<{
+		group: {
+			id: string;
+			status?: string;
+			updatedAt?: Timestamp;
+		};
+	}>();
+
+	let status = $state('');
+
+	function getGroupStatus() {
+		if (group.status === 'discussion') {
+			if (group.updatedAt) {
+				const diffInSeconds = Math.floor((Date.now() - group.updatedAt.toMillis()) / 1000);
+				if (diffInSeconds > 20) {
+					return `idle ${diffInSeconds} seconds`;
+				}
+			}
+			return 'discussion';
+		}
+		return group.status || 'waiting';
+	}
+
+	onMount(() => {
+		const statusInterval = setInterval(() => {
+			status = getGroupStatus();
+		}, 1000);
+
+		return () => clearInterval(statusInterval);
+	});
+</script>
+
+<span
+	class="rounded-full px-2 py-0.5 text-xs {status?.startsWith('idle')
+		? 'bg-red-100 text-red-600'
+		: status === 'discussion'
+			? 'bg-yellow-100 text-yellow-600'
+			: status === 'summarize'
+				? 'bg-blue-100 text-blue-600'
+				: status === 'end'
+					? 'bg-green-100 text-green-600'
+					: 'bg-gray-100 text-gray-600'}"
+>
+	{status || getGroupStatus()}
+</span>

--- a/src/lib/components/session/GroupStatus.svelte
+++ b/src/lib/components/session/GroupStatus.svelte
@@ -2,12 +2,13 @@
 	import { onMount } from 'svelte';
 	import type { Timestamp } from 'firebase/firestore';
 
-	let { group } = $props<{
+	let { group, showStatus = false } = $props<{
 		group: {
 			id: string;
 			status?: string;
 			updatedAt?: Timestamp;
 		};
+		showStatus?: boolean;
 	}>();
 
 	let status = $state('');
@@ -34,16 +35,18 @@
 	});
 </script>
 
-<span
-	class="rounded-full px-2 py-0.5 text-xs {status?.startsWith('idle')
-		? 'bg-red-100 text-red-600'
-		: status === 'discussion'
-			? 'bg-yellow-100 text-yellow-600'
-			: status === 'summarize'
-				? 'bg-blue-100 text-blue-600'
-				: status === 'end'
-					? 'bg-green-100 text-green-600'
-					: 'bg-gray-100 text-gray-600'}"
->
-	{status || getGroupStatus()}
-</span>
+{#if showStatus}
+	<span
+		class="rounded-full px-2 py-0.5 text-xs {status?.startsWith('idle')
+			? 'bg-red-100 text-red-600'
+			: status === 'discussion'
+				? 'bg-yellow-100 text-yellow-600'
+				: status === 'summarize'
+					? 'bg-blue-100 text-blue-600'
+					: status === 'end'
+						? 'bg-green-100 text-green-600'
+						: 'bg-gray-100 text-gray-600'}"
+	>
+		{status || getGroupStatus()}
+	</span>
+{/if}

--- a/src/lib/components/session/GroupSummary.svelte
+++ b/src/lib/components/session/GroupSummary.svelte
@@ -108,7 +108,7 @@
 		</div>
 	{:else}
 		<div class="text-center text-gray-600">
-			<p>點擊上方按鈕生成討論總結</p>
+			<p>尚無討論總結</p>
 		</div>
 	{/if}
 </div>

--- a/src/lib/components/session/HostView.svelte
+++ b/src/lib/components/session/HostView.svelte
@@ -19,10 +19,14 @@
 	import { renderMarkdown } from '$lib/utils/renderMarkdown';
 	import ChatHistory from './ChatHistory.svelte';
 	import GroupChatHistory from './GroupChatHistory.svelte';
+	import GroupStatus from './GroupStatus.svelte';
 
 	let { session }: { session: Readable<Session> } = $props();
 	let code = $state('');
-	type GroupWithId = Group & { id: string };
+	type GroupWithId = Group & {
+		id: string;
+		updatedAt: Timestamp | undefined;
+	};
 	let groups = writable<GroupWithId[]>([]);
 	let participantNames = $state(new Map<string, string>());
 	type ParticipantProgress = {
@@ -405,13 +409,16 @@
 				<div class="grid grid-cols-3 gap-4">
 					{#each [...$groups].sort((a, b) => a.number - b.number) as group}
 						<div class="rounded border p-3">
-							<button
-								class="mb-2 cursor-pointer text-sm font-semibold hover:text-primary-600"
-								onclick={() => handleGroupClick(group)}
-								onkeydown={(e) => e.key === 'Enter' && handleGroupClick(group)}
-							>
-								Group #{group.number}
-							</button>
+							<div class="mb-2 flex items-center justify-between">
+								<button
+									class="cursor-pointer text-sm font-semibold hover:text-primary-600"
+									onclick={() => handleGroupClick(group)}
+									onkeydown={(e) => e.key === 'Enter' && handleGroupClick(group)}
+								>
+									Group #{group.number}
+								</button>
+								<GroupStatus {group} />
+							</div>
 							{#if group.participants.length === 0}
 								<p class="text-xs text-gray-500">No participants</p>
 							{:else}

--- a/src/lib/components/session/HostView.svelte
+++ b/src/lib/components/session/HostView.svelte
@@ -417,7 +417,7 @@
 								>
 									Group #{group.number}
 								</button>
-								<GroupStatus {group} />
+								<GroupStatus {group} showStatus={$session?.status === 'group'} />
 							</div>
 							{#if group.participants.length === 0}
 								<p class="text-xs text-gray-500">No participants</p>

--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -17,6 +17,7 @@
 	import Summary from '$lib/components/session/Summary.svelte';
 	import GroupSummary from '$lib/components/session/GroupSummary.svelte';
 	import { initFFmpeg, float32ArrayToWav, wav2mp3 } from '$lib/utils/wav2mp3';
+	import EndedView from '$lib/components/session/EndedView.svelte';
 
 	interface ChatroomConversation {
 		name: string;
@@ -672,15 +673,7 @@
 					{/if}
 				</div>
 			{:else if $session?.status === 'ended'}
-				{#if groupDoc}
-					<GroupSummary
-						readonly
-						group={groupDoc}
-						loading={loadingGroupSummary}
-						onRefresh={fetchGroupSummary}
-						onUpdate={handleUpdateGroupSummary}
-					/>
-				{/if}
+				<EndedView {conversationDoc} {groupDoc} {user} />
 			{/if}
 		</div>
 	</div>

--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -67,6 +67,9 @@
 		if ($session?.status === 'before-group' && conversationDoc && !conversationDoc.data.summary) {
 			fetchSummary();
 		}
+		if ($session?.status === 'ended' && groupDoc && !groupDoc.data.summary) {
+			fetchGroupSummary();
+		}
 	});
 
 	function updateConversationDoc() {
@@ -668,6 +671,16 @@
 						{/if}
 					{/if}
 				</div>
+			{:else if $session?.status === 'ended'}
+				{#if groupDoc}
+					<GroupSummary
+						readonly
+						group={groupDoc}
+						loading={loadingGroupSummary}
+						onRefresh={fetchGroupSummary}
+						onUpdate={handleUpdateGroupSummary}
+					/>
+				{/if}
 			{/if}
 		</div>
 	</div>

--- a/src/lib/components/session/Summary.svelte
+++ b/src/lib/components/session/Summary.svelte
@@ -59,7 +59,7 @@
 		</div>
 	{:else}
 		<div class="text-center text-gray-600">
-			<p>點擊上方按鈕生成對話總結</p>
+			<p>尚無對話總結</p>
 		</div>
 	{/if}
 </div>

--- a/src/routes/api/session/[id]/group/+server.ts
+++ b/src/routes/api/session/[id]/group/+server.ts
@@ -32,7 +32,9 @@ export const POST: RequestHandler = async ({ params, locals }) => {
 			summary: null,
 			keywords: {},
 			number: groupNumber,
-			createdAt: new Date()
+			createdAt: new Date(),
+			status: 'discussion',
+			updatedAt: new Date()
 		};
 
 		const result = GroupSchema.safeParse(groupData);


### PR DESCRIPTION
- show the group history in HostView
- show the group status in HostView
- show the individual and group discussion history in EndedView 

This pull request introduces several new features and improvements to the session components, including adding a new `EndedView` component, enhancing group chat history functionality, and updating group status handling. The most important changes include the addition of new components, updates to existing components, and improvements to the group status functionality.

### New Components and Features:
* [`src/lib/components/session/EndedView.svelte`](diffhunk://#diff-46b4737e818d95d9042067797c481e6ba3ce01ee07df7402c841c23a93a354efR1-R107): Added a new `EndedView` component to display individual and group summaries, chat history, and group discussions. [[1]](diffhunk://#diff-46b4737e818d95d9042067797c481e6ba3ce01ee07df7402c841c23a93a354efR1-R107) [[2]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R675-R676)
* [`src/lib/components/session/GroupChatHistory.svelte`](diffhunk://#diff-051c193682d2494894fd264e069fd081e5c641844baa3fef89b57f553c7baafeR1-R57): Added a new component to handle group chat history and summaries within a modal.

### Updates to Existing Components:
* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR21-R29): Integrated `GroupChatHistory` and `GroupStatus` components, and added functionality to handle group clicks and display group chat history. [[1]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR21-R29) [[2]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR50-R61) [[3]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR319-R339) [[4]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL374-R421) [[5]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR520-R523)
* [`src/lib/components/session/ParticipantView.svelte`](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R20): Updated to display the new `EndedView` component when the session status is 'ended'. [[1]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R20) [[2]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R71-R73)

### Group Status Handling:
* [`src/lib/components/session/GroupStatus.svelte`](diffhunk://#diff-1ac549872686ed1483781a82bcf4b4603a9045f00df1197de7c6f1734d38e9c6R1-R52): Added a new component to handle and display the status of groups, including idle and discussion states.
* `src/routes/api/session/[id]/group/+server.ts`: Updated group creation to include `status` and `updatedAt` fields. ([src/routes/api/session/[id]/group/+server.tsL35-R37](diffhunk://#diff-e96aacd66a001f3bb0241610aca39d2ce3e86f764723f02b16e576ab182e4d44L35-R37))

### Minor Text Updates:
* [`src/lib/components/session/Summary.svelte`](diffhunk://#diff-6cee0d6a750115c7cc09e81e8b659933ce0464633d2db7830a0544b86a50d530L62-R62): Updated text to indicate no conversation summary available.
* [`src/lib/components/session/GroupSummary.svelte`](diffhunk://#diff-dc8a44a089a402d73b71ebbfdf6381efab1453ca5ad71277e0342a2c4feade30L111-R111): Updated text to indicate no discussion summary available.