### PR TITLE
feat: warning handling, page title and button style in EndedView 

### DIFF
--- a/src/lib/components/session/EndedView.svelte
+++ b/src/lib/components/session/EndedView.svelte
@@ -47,7 +47,7 @@
 	<div class="flex space-x-4">
 		<button
 			class="rounded-lg px-4 py-2 {activeTab === 'summary'
-				? 'bg-blue-500 text-white'
+				? 'bg-primary-600 text-white'
 				: 'bg-gray-200'}"
 			onclick={() => (activeTab = 'summary')}
 		>
@@ -55,21 +55,23 @@
 		</button>
 		<button
 			class="rounded-lg px-4 py-2 {activeTab === 'groupSummary'
-				? 'bg-blue-500 text-white'
+				? 'bg-primary-600 text-white'
 				: 'bg-gray-200'}"
 			onclick={() => (activeTab = 'groupSummary')}
 		>
 			群組總結
 		</button>
 		<button
-			class="rounded-lg px-4 py-2 {activeTab === 'chat' ? 'bg-blue-500 text-white' : 'bg-gray-200'}"
+			class="rounded-lg px-4 py-2 {activeTab === 'chat'
+				? 'bg-primary-600 text-white'
+				: 'bg-gray-200'}"
 			onclick={() => (activeTab = 'chat')}
 		>
 			個人對話歷史
 		</button>
 		<button
 			class="rounded-lg px-4 py-2 {activeTab === 'groupChat'
-				? 'bg-blue-500 text-white'
+				? 'bg-primary-600 text-white'
 				: 'bg-gray-200'}"
 			onclick={() => (activeTab = 'groupChat')}
 		>

--- a/src/lib/components/session/HostView.svelte
+++ b/src/lib/components/session/HostView.svelte
@@ -159,7 +159,7 @@
 			limit(1)
 		);
 		const codeDoc = (await getDocs(codeQuery)).docs[0];
-		console.log(codeDoc.data());
+		//console.log(codeDoc.data());
 
 		if (!codeDoc || Timestamp.now().toMillis() - codeDoc.data()?.createTime.toMillis() > 3600000) {
 			code = await genCode();

--- a/src/lib/components/session/HostView.svelte
+++ b/src/lib/components/session/HostView.svelte
@@ -264,6 +264,39 @@
 		}
 	}
 
+	async function handleRemoveWarning(groupId: string, participant: string) {
+		try {
+			const conversationsRef = collection(
+				db,
+				`sessions/${$page.params.id}/groups/${groupId}/conversations`
+			);
+			const snapshot = await getDocs(conversationsRef);
+			const conversationDoc = snapshot.docs.find(
+				(doc) => (doc.data() as Conversation).userId === participant
+			);
+
+			if (!conversationDoc) {
+				throw new Error('Conversation not found');
+			}
+
+			const response = await fetch(
+				`/api/session/${$page.params.id}/group/${groupId}/conversations/${conversationDoc.id}/remove/warning`,
+				{
+					method: 'GET'
+				}
+			);
+
+			if (!response.ok) {
+				throw new Error('Failed to remove warning');
+			}
+
+			notifications.success('成功移除警告', 3000);
+		} catch (error) {
+			console.error('無法移除警告:', error);
+			notifications.error('無法移除警告');
+		}
+	}
+
 	const stageButton = $derived({
 		preparing: {
 			text: 'Start Individual Stage',
@@ -479,9 +512,20 @@
 																				: ''}"
 																	>
 																		{#if warning.moderation}
-																			<TriangleAlert class="h-3 w-3 text-white" />
+																			<button
+																				class="flex items-center justify-center"
+																				onclick={() => handleRemoveWarning(group.id, participant)}
+																				title="點擊移除內容警告"
+																			>
+																				<TriangleAlert
+																					class="h-3 w-3 text-white hover:text-gray-200"
+																				/>
+																			</button>
 																		{:else if warning.offTopic >= 3}
-																			<MessageSquareOff class="h-3 w-3 text-white" />
+																			<MessageSquareOff
+																				class="h-3 w-3 text-white"
+																				aria-label="離題警告"
+																			/>
 																		{/if}
 																	</div>
 																{/if}

--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -3,6 +3,7 @@
 	import type { Session } from '$lib/schema/session';
 	import type { Group } from '$lib/schema/group';
 	import type { Conversation } from '$lib/schema/conversation';
+	import type { Profile } from '$lib/schema/profile';
 	import type { Readable } from 'svelte/store';
 	import { Button, Input, Label } from 'flowbite-svelte';
 	import { notifications } from '$lib/stores/notifications';
@@ -42,11 +43,12 @@
 	let loadingGroupSummary = $state(false);
 
 	let pInitFFmpeg: Promise<void> | null = null;
+	let selfUser: Promise<Profile> | null = null;
 
 	onMount(() => {
 		const groupsRef = collection(db, 'sessions', $page.params.id, 'groups');
 		const groupDocQuery = query(groupsRef, where('participants', 'array-contains', user.uid));
-
+		selfUser = getUser(user.uid);
 		const unsbscribe = onSnapshot(groupDocQuery, (snapshot) => {
 			if (snapshot.empty) {
 				return;
@@ -332,7 +334,7 @@
 					},
 					body: JSON.stringify({
 						content: text,
-						speaker: $authUser?.displayName || 'Unknown User',
+						speaker: (await selfUser)?.displayName || 'Unknown User',
 						audio: null
 					})
 				}

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -47,10 +47,10 @@ async function isHarmfulContent(
 async function isOffTopic(
 	history: LLMChatMessage[],
 	prompt: string
-): Promise<{ success: boolean; off_topic: number; error?: string }> {
+): Promise<{ success: boolean; off_topic: boolean; error?: string }> {
 	console.log('Checking if off topic:', { historyLength: history.length });
-	if (history.length < 2) {
-		return { success: true, off_topic: 0 };
+	if (history.length < 1) {
+		return { success: true, off_topic: false };
 	}
 	try {
 		const llm_message = history.length > 1 ? history[history.length - 2].content : prompt;
@@ -60,7 +60,7 @@ async function isOffTopic(
 			student_message
 		);
 
-		const response = await requestZodLLM(system_prompt, z.object({ result: z.number() }));
+		const response = await requestZodLLM(system_prompt, z.object({ result: z.boolean() }));
 
 		if (!response.success) {
 			throw new Error('Failed to detect off topic response');
@@ -75,7 +75,7 @@ async function isOffTopic(
 		console.error('Error in isOffTopic:', error);
 		return {
 			success: false,
-			off_topic: 0,
+			off_topic: false,
 			error: 'Failed to detect off topic'
 		};
 	}
@@ -185,7 +185,7 @@ export async function chatWithLLMByDocs(
 	success: boolean;
 	message: string;
 	subtask_completed: boolean[];
-	warning: { off_topic: number; moderation: boolean };
+	warning: { off_topic: boolean; moderation: boolean };
 	error?: string;
 }> {
 	console.log('Starting chatWithLLMByDocs:', {
@@ -209,9 +209,7 @@ export async function chatWithLLMByDocs(
 		const [response, subtask_completed, moderation, off_topic] = await Promise.all([
 			requestChatLLM(system_prompt, history, temperature),
 			checkSubtaskCompleted(history, subtasks),
-			...(history.length
-				? [isHarmfulContent(history[history.length - 1].content)]
-				: [{ success: true, harmful: false }]),
+			isHarmfulContent(history.length > 0 ? history[history.length - 1].content : ''),
 			isOffTopic(history, system_prompt)
 		]);
 
@@ -229,8 +227,8 @@ export async function chatWithLLMByDocs(
 			message: response.message,
 			subtask_completed: subtask_completed.completed,
 			warning: {
-				moderation: false,
-				off_topic: 0
+				moderation: moderation.harmful,
+				off_topic: off_topic.off_topic
 			}
 		};
 	} catch (error) {
@@ -239,7 +237,7 @@ export async function chatWithLLMByDocs(
 			success: false,
 			message: '',
 			subtask_completed: [],
-			warning: { moderation: false, off_topic: 0 },
+			warning: { moderation: false, off_topic: false },
 			error: 'Failed to chat with LLM by docs'
 		};
 	}

--- a/src/lib/utils/firestore.ts
+++ b/src/lib/utils/firestore.ts
@@ -33,7 +33,8 @@ export async function createConversation(
 		subtasks: subtasks,
 		resources: resources,
 		history: history,
-		subtaskCompleted: new Array(subtasks.length).fill(false)
+		subtaskCompleted: new Array(subtasks.length).fill(false),
+		warning: { moderation: false, off_topic: 0 }
 	});
 
 	return conversationRef.id;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,10 @@
 	import { ArrowRight, Mic, Brain, GraduationCap, Github } from 'lucide-svelte';
 </script>
 
+<svelte:head>
+	<title>Home | Hinagiku</title>
+</svelte:head>
+
 <main class="min-h-screen">
 	<div class="bg-gradient-to-b from-primary-50 to-white">
 		<div class="mx-auto max-w-6xl px-4 py-24">

--- a/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/chat/+server.ts
+++ b/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/chat/+server.ts
@@ -69,7 +69,9 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 			console.error('LLM response failed:', response.error);
 			throw error(500, response.error);
 		}
-
+		if (isNaN(warning.offTopic)) {
+			warning.offTopic = 0;
+		}
 		await conversation_ref.update({
 			history: [
 				...history,

--- a/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/remove/warning/+server.ts
+++ b/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/remove/warning/+server.ts
@@ -25,7 +25,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 		conversation_ref.update({
 			warning: {
 				moderation: false,
-				offTopic: false
+				offTopic: (await conversation_ref.get()).data()?.warning?.offTopic || 0
 			}
 		});
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -115,6 +115,10 @@
 	});
 </script>
 
+<svelte:head>
+	<title>Dashboard | Hinagiku</title>
+</svelte:head>
+
 <main class="mx-auto max-w-6xl px-4 py-16">
 	<div class="mb-12">
 		<h1 class="text-3xl font-bold text-gray-900">Dashboard</h1>

--- a/src/routes/dashboard/recent/host/+page.svelte
+++ b/src/routes/dashboard/recent/host/+page.svelte
@@ -24,6 +24,10 @@
 	});
 </script>
 
+<svelte:head>
+	<title>Recent Host Sessions | Hinagiku</title>
+</svelte:head>
+
 <main class="mx-auto max-w-6xl px-4 py-16">
 	<div class="mb-12 flex items-center justify-between">
 		<div>

--- a/src/routes/dashboard/recent/participant/+page.svelte
+++ b/src/routes/dashboard/recent/participant/+page.svelte
@@ -39,6 +39,10 @@
 	getSessions();
 </script>
 
+<svelte:head>
+	<title>Recent Participant Sessions | Hinagiku</title>
+</svelte:head>
+
 <main class="mx-auto max-w-6xl px-4 py-16">
 	<div class="mb-12 flex items-center justify-between">
 		<div>

--- a/src/routes/session/[id]/+page.svelte
+++ b/src/routes/session/[id]/+page.svelte
@@ -10,6 +10,10 @@
 	let isHost = $derived($session?.host === data.user.uid);
 </script>
 
+<svelte:head>
+	<title>Session | Hinagiku</title>
+</svelte:head>
+
 {#if isHost}
 	<HostView {session} />
 {:else}


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the application. The most important changes include updating button styles, adding a new function for handling warnings, and ensuring proper handling of conversation warnings. Additionally, several pages now have dynamic titles for better user navigation.

UI Improvements:
* [`src/lib/components/session/EndedView.svelte`](diffhunk://#diff-46b4737e818d95d9042067797c481e6ba3ce01ee07df7402c841c23a93a354efL50-R74): Updated button styles to use `bg-primary-600` instead of `bg-blue-500` for better consistency with the design system.

New Functionality:
* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR267-R299): Added `handleRemoveWarning` function to remove warnings from conversations, including error handling and user notifications.
* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL482-R528): Modified the warning icon to include a button that triggers `handleRemoveWarning` when clicked.

Bug Fixes:
* [`src/lib/server/llm.ts`](diffhunk://#diff-397182a15b1a3feeafc214c2cdd56d912e8f2857276b09a70808c989f0b287ffR52-R54): Ensured `isOffTopic` function returns correctly when history is empty.
* `src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/remove/warning/+server.ts`: Corrected the `offTopic` warning reset logic to default to 0 if not present. ([src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/remove/warning/+server.tsL28-R28](diffhunk://#diff-c5a57b9c6906cd16ed355129ef4b074af3d234cd9f4d81d068059b0a98f4381dL28-R28))

User Experience Enhancements:
* Various files: Added dynamic titles to multiple pages (`Home`, `Dashboard`, `Recent Host Sessions`, `Recent Participant Sessions`, `Session`) for better navigation and SEO. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR7-R10) [[2]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581R118-R121) [[3]](diffhunk://#diff-488bac84c3b32b69f13dda2b6dea94254e08a68c7f7b2246c1c06df1bb61dcecR27-R30) [[4]](diffhunk://#diff-b43c5747036319347edcb1742eac78c53d5f7e47f253cabca5750ef5ed470745R42-R45) [src/routes/session/[id]/+page.svelteR13-R16](diffhunk://#diff-9c49d9b22839f82b1cc6c582a6c02a60e702a34879fb27ca6bc836fda2c09f59R13-R16))