### PR TITLE
feat: show most active participants and groups, word cloud in Ended Stage

### DIFF
--- a/src/lib/components/session/MostActiveParticipants.svelte
+++ b/src/lib/components/session/MostActiveParticipants.svelte
@@ -14,7 +14,6 @@
 
 	// Add user name mapping store
 	let userNames = new Map<string, string>();
-	let loading = true;
 
 	function getColorByRatio(ratio: number): string {
 		const h = 12;
@@ -24,7 +23,7 @@
 	}
 
 	async function updateChart() {
-		if (!container) return;
+		if (!container || !conversations || conversations.length === 0) return;
 
 		if (!chart) {
 			chart = echarts.init(container);
@@ -46,7 +45,6 @@
 
 		// Load user profiles if not cached
 		const userIds = Object.keys(participantData);
-		loading = true;
 
 		await Promise.all(
 			userIds.map(async (uid) => {
@@ -57,13 +55,11 @@
 			})
 		);
 
-		loading = false;
-
 		const sortedData = Object.entries(participantData)
 			.sort(([, a], [, b]) => b - a)
 			.slice(0, 5)
 			.reverse();
-
+		console.log('sortedData', sortedData);
 		const maxValue = sortedData[sortedData.length - 1][1];
 
 		chart.setOption({
@@ -111,13 +107,15 @@
 	});
 
 	$effect(() => {
-		if (!loading && conversations && chart) {
+		if (conversations && conversations.length > 0) {
 			updateChart();
 		}
 	});
 
 	onMount(() => {
-		updateChart();
+		if (conversations && conversations.length > 0) {
+			updateChart();
+		}
 	});
 
 	onDestroy(() => {
@@ -125,4 +123,8 @@
 	});
 </script>
 
-<div bind:this={container} class="h-full w-full"></div>
+<div bind:this={container} class="h-full w-full">
+	{#if !conversations || conversations.length === 0}
+		<div class="flex h-full w-full items-center justify-center text-gray-500">暫無數據</div>
+	{/if}
+</div>

--- a/src/routes/api/session/[id]/conversations/+server.ts
+++ b/src/routes/api/session/[id]/conversations/+server.ts
@@ -1,0 +1,13 @@
+import { getConversationsFromAllParticipantsData } from '$lib/utils/firestore';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params }) => {
+	try {
+		const conversations = await getConversationsFromAllParticipantsData(params.id);
+		return json(conversations);
+	} catch (err) {
+		console.error('Error fetching conversations:', err);
+		throw error(500, '無法獲取對話資料');
+	}
+};

--- a/src/routes/api/session/[id]/conversations/keywords/+server.ts
+++ b/src/routes/api/session/[id]/conversations/keywords/+server.ts
@@ -1,0 +1,27 @@
+import { getGroupsData, getGroupsRef } from '$lib/utils/firestore';
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ params }) => {
+	try {
+		const groupsRef = getGroupsRef(params.id);
+		const groups = await getGroupsData(groupsRef);
+
+		// 建立關鍵字頻率統計
+		const keywordFrequency: Record<string, number> = {};
+
+		// 遍歷所有群組的關鍵字
+		groups.forEach((group) => {
+			if (group.keywords) {
+				Object.entries(group.keywords).forEach(([, count]) => {
+					keywordFrequency[count] = (keywordFrequency[count] || 0) + 1;
+				});
+			}
+		});
+
+		return json(keywordFrequency);
+	} catch (err) {
+		console.error('Error fetching data:', err);
+		throw error(500, '無法獲取資料');
+	}
+};

--- a/src/routes/api/session/[id]/conversations/most-active-participants/+server.ts
+++ b/src/routes/api/session/[id]/conversations/most-active-participants/+server.ts
@@ -7,7 +7,7 @@ export const GET: RequestHandler = async ({ params }) => {
 		const conversations = await getConversationsFromAllParticipantsData(params.id);
 		return json(conversations);
 	} catch (err) {
-		console.error('Error fetching conversations:', err);
-		throw error(500, '無法獲取對話資料');
+		console.error('Error fetching data:', err);
+		throw error(500, '無法獲取資料');
 	}
 };


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and data handling in the `HostView` component and related modules. The most important changes include adding new data fetching functions, updating components to handle new data, and adding new API endpoints.

Data fetching and state management:

* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR77-R78): Introduced `conversationsData` and `keywordData` states, and added `loadConversationsData` and `loadKeywordData` functions to fetch data from new API endpoints. These functions are called when the session status is 'ended'. [[1]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR77-R78) [[2]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR413-R456)

Component updates:

* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL457-R510): Updated `WordCloud`, `MostActiveParticipants`, and `MostActiveGroups` components to use the new data states.
* [`src/lib/components/session/MostActiveParticipants.svelte`](diffhunk://#diff-94fc219addeb6e5e32ff6f1021074a386720eaa86807aff76873683b9aef37e8L17): Removed the `loading` state and updated the chart rendering logic to handle the new `conversations` prop. Added a message to display when there is no data. [[1]](diffhunk://#diff-94fc219addeb6e5e32ff6f1021074a386720eaa86807aff76873683b9aef37e8L17) [[2]](diffhunk://#diff-94fc219addeb6e5e32ff6f1021074a386720eaa86807aff76873683b9aef37e8L27-R26) [[3]](diffhunk://#diff-94fc219addeb6e5e32ff6f1021074a386720eaa86807aff76873683b9aef37e8L49) [[4]](diffhunk://#diff-94fc219addeb6e5e32ff6f1021074a386720eaa86807aff76873683b9aef37e8L60-R62) [[5]](diffhunk://#diff-94fc219addeb6e5e32ff6f1021074a386720eaa86807aff76873683b9aef37e8L114-R130)

New API endpoints:

* `src/routes/api/session/[id]/conversations/keywords/+server.ts`: Added an endpoint to fetch keyword frequency data for a session. ([src/routes/api/session/[id]/conversations/keywords/+server.tsR1-R27](diffhunk://#diff-ab41db5e4999fe1f7249de066d1c88b1d98329168f66e6e8819ef00e3468713dR1-R27))
* `src/routes/api/session/[id]/conversations/most-active-participants/+server.ts`: Added an endpoint to fetch the most active participants' conversation data for a session. ([src/routes/api/session/[id]/conversations/most-active-participants/+server.tsR1-R13](diffhunk://#diff-783c5abc873508288a1b4c3f9b108f47a4486c1c95e38eafda6b482f338b5adaR1-R13))

Utility functions:

* [`src/lib/utils/firestore.ts`](diffhunk://#diff-8e141e7749c7e59c246d34464a320bd8710af902d435289efb30217f22decdabR130-R162): Added `getConversationsFromAllParticipantsData` function to fetch all conversations from all participants in a session.