### PR TITLE
fix: keyword is not fetched correctly in API

### DIFF
--- a/src/routes/api/session/[id]/conversations/keywords/+server.ts
+++ b/src/routes/api/session/[id]/conversations/keywords/+server.ts
@@ -13,8 +13,8 @@ export const GET: RequestHandler = async ({ params }) => {
 		// 遍歷所有群組的關鍵字
 		groups.forEach((group) => {
 			if (group.keywords) {
-				Object.entries(group.keywords).forEach(([, count]) => {
-					keywordFrequency[count] = (keywordFrequency[count] || 0) + 1;
+				Object.entries(group.keywords).forEach(([keyword, count]) => {
+					keywordFrequency[keyword] = (keywordFrequency[keyword] || 0) + count;
 				});
 			}
 		});


### PR DESCRIPTION
This pull request includes a change to the `GET` request handler in the `src/routes/api/session/[id]/conversations/keywords/+server.ts` file. The change improves the calculation of keyword frequencies by correctly using the keyword as the key and adding the count to the existing frequency.

* `src/routes/api/session/[id]/conversations/keywords/+server.ts`: Modified the `Object.entries` method to correctly use `keyword` as the key and add `count` to `keywordFrequency`. ([src/routes/api/session/[id]/conversations/keywords/+server.tsL16-R17](diffhunk://#diff-ab41db5e4999fe1f7249de066d1c88b1d98329168f66e6e8819ef00e3468713dL16-R17))