### PR TITLE
fix: previous stage not show on loading

### DIFF
--- a/src/lib/components/session/StageProgress.svelte
+++ b/src/lib/components/session/StageProgress.svelte
@@ -91,7 +91,7 @@
 
 {#if showAction}
 	<div class="flex items-center gap-2">
-		{#if canGoPrevious}
+		{#if canGoPrevious || loadingPrevious}
 			<Button color="light" on:click={handlePrevious} disabled={!canGoPrevious || loadingPrevious}>
 				{#if loadingPrevious && currentStageIndex > 0}
 					<Loader2 class="h-4 w-4 animate-spin" />


### PR DESCRIPTION
This pull request includes a change to the `StageProgress.svelte` file to improve the user experience during stage transitions. The most important change is the addition of a condition to handle the loading state for the "Previous" button, ensuring that it is disabled appropriately during the loading process.

User experience improvement:

* [`src/lib/components/session/StageProgress.svelte`](diffhunk://#diff-2f9d93aa3b5adaaf7b2bbbc60e2c4f5833aea1c8c5d76adac61abe94a780f9c9L94-R94): Added `loadingPrevious` condition to the "Previous" button to handle the loading state and ensure it is disabled when necessary.