### PR TITLE
sytle: change ai assistant name

### DIFF
--- a/src/lib/components/session/EndedView.svelte
+++ b/src/lib/components/session/EndedView.svelte
@@ -17,7 +17,7 @@
 		if (!conversationDoc) return [];
 		return conversationDoc.data.history.map(
 			(message: { role: string; content: string; audio?: string }) => ({
-				name: message.role === 'user' ? 'You' : 'AI Assistant',
+				name: message.role === 'user' ? 'You' : '小菊(Hinagiku)',
 				content: message.content,
 				self: message.role === 'user',
 				audio: message.audio || undefined

--- a/src/lib/components/session/HostView.svelte
+++ b/src/lib/components/session/HostView.svelte
@@ -376,7 +376,7 @@
 				selectedParticipant = {
 					displayName: userData.displayName,
 					history: conversations[0].history.map((message) => ({
-						name: message.role === 'user' ? userData.displayName : 'AI Assistant',
+						name: message.role === 'user' ? userData.displayName : '小菊(Hinagiku)',
 						content: message.content,
 						self: message.role === 'user',
 						audio: message.audio || undefined

--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -114,7 +114,7 @@
 			return [];
 		}
 		return conversationDoc.data.history.map((message) => ({
-			name: message.role === 'user' ? 'You' : 'AI Assistant',
+			name: message.role === 'user' ? 'You' : '小菊(Hinagiku)',
 			self: message.role === 'user',
 			content: message.content,
 			audio: message.audio || undefined


### PR DESCRIPTION
This pull request includes changes to the naming convention for the AI assistant in multiple components. The AI assistant's name has been updated from 'AI Assistant' to '小菊(Hinagiku)'.

Updates to naming convention:

* [`src/lib/components/session/EndedView.svelte`](diffhunk://#diff-46b4737e818d95d9042067797c481e6ba3ce01ee07df7402c841c23a93a354efL20-R20): Changed the AI assistant's name to '小菊(Hinagiku)' in the conversation history mapping.
* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL379-R379): Updated the AI assistant's name to '小菊(Hinagiku)' in the selected participant's conversation history.
* [`src/lib/components/session/ParticipantView.svelte`](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96L117-R117): Modified the AI assistant's name to '小菊(Hinagiku)' in the participant's conversation history mapping.