### PR TITLE
fix: summary not shown properly, change keywords style

### DIFF
--- a/src/lib/components/session/GroupSummary.svelte
+++ b/src/lib/components/session/GroupSummary.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
 	import type { Group } from '$lib/schema/group';
 
+	const tagColors = [
+		'bg-blue-100 text-blue-700',
+		'bg-green-100 text-green-700',
+		'bg-purple-100 text-purple-700',
+		'bg-pink-100 text-pink-700',
+		'bg-yellow-100 text-yellow-700'
+	];
+
 	export let group: {
 		data: Group;
 		id: string;
@@ -103,11 +111,13 @@
 							/>
 						{/each}
 					{:else}
-						<ul class="list-inside list-disc space-y-2">
-							{#each summaryData.keywords as { text }}
-								<li class="text-gray-700">{text}</li>
+						<div class="flex flex-wrap gap-2">
+							{#each summaryData.keywords as { text }, i}
+								<span class="rounded-full px-3 py-1 text-sm {tagColors[i % tagColors.length]}">
+									#{text}
+								</span>
 							{/each}
-						</ul>
+						</div>
 					{/if}
 				</div>
 			{/if}

--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -553,6 +553,8 @@
 					<CircleCheck class="mr-2 h-4 w-4" />
 					Confirm Group Summary
 				</Button>
+			{:else if groupStatus === 'end'}
+				<p class="text-gray-600">Please wait for the host to finish</p>
 			{/if}
 		{/if}
 	</div>

--- a/src/lib/server/types.ts
+++ b/src/lib/server/types.ts
@@ -18,10 +18,7 @@ export interface Discussion {
 	id: string | null;
 	content: string;
 	speaker: string;
-	warning: {
-		moderation: boolean;
-		offTopic: boolean;
-	};
+	moderation: boolean;
 }
 
 export interface SummaryData {

--- a/src/routes/api/session/[id]/group/[group_number]/discussions/summary/+server.ts
+++ b/src/routes/api/session/[id]/group/[group_number]/discussions/summary/+server.ts
@@ -53,7 +53,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 // Request data format
 const requestDataFormat = z.object({
 	updated_summary: z.string(),
-	keywords: z.array(z.string())
+	keywords: z.record(z.string(), z.number())
 });
 
 export const PUT: RequestHandler = async ({ request, params, locals }) => {


### PR DESCRIPTION
This pull request includes several changes to the `GroupSummary.svelte`, `ParticipantView.svelte`, `types.ts`, and `+server.ts` files. The main improvements focus on updating the handling of keywords, adding new UI elements, and modifying data structures.

### Handling of Keywords:

* [`src/lib/components/session/GroupSummary.svelte`](diffhunk://#diff-dc8a44a089a402d73b71ebbfdf6381efab1453ca5ad71277e0342a2c4feade30R4-R49): Changed the `onUpdate` function to accept a `Record<string, number>` for keywords instead of an array of strings. Updated the `editedKeywords` structure to include text and weight properties, and modified the keyword sorting and mapping logic accordingly.

### UI Enhancements:

* [`src/lib/components/session/GroupSummary.svelte`](diffhunk://#diff-dc8a44a089a402d73b71ebbfdf6381efab1453ca5ad71277e0342a2c4feade30L87-R120): Added a new array `tagColors` for styling keyword tags and updated the keyword display to show colored tags instead of a list.
* [`src/lib/components/session/ParticipantView.svelte`](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R556-R557): Added a message prompting users to wait for the host to finish when the group status is 'end'.

### Data Structure Modifications:

* [`src/lib/server/types.ts`](diffhunk://#diff-6c27dcdb1f8c3ee6121c95bb623fa0cd9188d3efe02c8306a9e18e33d38ca4a0L21-L24): Removed the `warning` property from the `Discussion` interface.
* `src/routes/api/session/[id]/group/[group_number]/discussions/summary/+server.ts`: Updated the `keywords` validation schema to accept a record of strings to numbers instead of an array of strings. ([src/routes/api/session/[id]/group/[group_number]/discussions/summary/+server.tsL56-R56](diffhunk://#diff-55442441ee5b3407c874368b76f6fdf140d1ae051c7d18538b0d6b7591c892f4L56-R56))