### PR TITLE
fix: ASR hallucination on ending silence

### DIFF
--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -215,7 +215,8 @@
 
 				await pInitFFmpeg;
 				console.log('Audio recorded:', audio);
-				const wav = float32ArrayToWav(audio);
+				// remove last 8000 samples (0.5s)
+				const wav = float32ArrayToWav(audio.slice(0, -8000));
 				console.log('Audio converted to wav:', wav);
 				const mp3 = await wav2mp3(wav);
 				console.log('Audio converted to mp3:', mp3);
@@ -376,7 +377,8 @@
 
 				await pInitFFmpeg;
 				console.log('Audio recorded:', audio);
-				const wav = float32ArrayToWav(audio);
+				// remove last 8000 samples (0.5s)
+				const wav = float32ArrayToWav(audio.slice(0, -8000));
 				console.log('Audio converted to wav:', wav);
 				const mp3 = await wav2mp3(wav);
 				console.log('Audio converted to mp3:', mp3);

--- a/src/lib/stt/gemini.ts
+++ b/src/lib/stt/gemini.ts
@@ -17,5 +17,5 @@ export async function transcribe(data: Buffer): Promise<string> {
 		throw new Error('Failed to transcribe audio');
 	}
 
-	return output.transcription;
+	return output.transcription.replace(/[嗶.…]+$/g, '');
 }


### PR DESCRIPTION
work around on resolving #78 

This pull request includes several changes to improve audio processing and transcription functionalities. The key changes involve trimming audio data and cleaning up transcription results.

Audio processing improvements:

* [`src/lib/components/session/ParticipantView.svelte`](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96L218-R219): Modified the `float32ArrayToWav` function call to remove the last 8000 samples (0.5 seconds) from the audio data before converting it to WAV format. This change was made in two places within the file. [[1]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96L218-R219) [[2]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96L379-R381)

Transcription cleanup:

* [`src/lib/stt/gemini.ts`](diffhunk://#diff-c035fe9c12f9ba047a3fd1f2642b4da6ed8dafb7194012fb20bf31c08db4260aL20-R20): Updated the transcription function to remove unwanted characters (嗶, …) from the end of the transcription result using a regular expression.