### PR TITLE
fix: bug template with title in english characters without spaces will cause UI issue, minor style updated

### DIFF
--- a/src/lib/components/session/HostView.svelte
+++ b/src/lib/components/session/HostView.svelte
@@ -483,28 +483,30 @@
 </script>
 
 <main class="mx-auto max-w-7xl px-4 py-16">
-	<div class="mb-8 flex items-center justify-between">
-		<div class="flex items-center gap-4">
-			<h1 class="text-3xl font-bold">{$session?.title}</h1>
-			{#if $session?.status === 'preparing'}
-				<LabelManager sessionId={$page.params.id} labels={$session?.labels || []} />
-			{:else if $session?.labels?.length}
-				<div class="flex items-center gap-2">
-					{#each $session.labels as label}
-						<span class="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600">
-							{label}
-						</span>
-					{/each}
-				</div>
-			{/if}
-		</div>
+	<div class="mb-8 flex flex-col gap-4">
+		{#if $session?.status === 'preparing'}
+			<LabelManager sessionId={$page.params.id} labels={$session?.labels || []} />
+		{:else if $session?.labels?.length}
+			<div class="flex items-center gap-2">
+				{#each $session.labels as label}
+					<span class="rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-600">
+						{label}
+					</span>
+				{/each}
+			</div>
+		{/if}
+		<div class="flex items-center justify-between">
+			<h1 class="text-3xl font-bold">
+				{$session?.title}
+			</h1>
 
-		<div class="flex items-center gap-6">
-			<StageProgress
-				session={$session}
-				onStageChange={handleStageChange}
-				showAction={$session && stageButton[$session.status].show}
-			/>
+			<div class="flex items-center gap-6">
+				<StageProgress
+					session={$session}
+					onStageChange={handleStageChange}
+					showAction={$session && stageButton[$session.status].show}
+				/>
+			</div>
 		</div>
 	</div>
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -329,7 +329,22 @@
 				{#each $filteredHostSessions as [doc, session]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 line-clamp-1 text-xl font-bold">{session.title}</h3>
+							<div class="mb-4 flex items-start justify-between">
+								<h3 class="line-clamp-1 text-xl font-bold">{session.title}</h3>
+								<span
+									class="rounded-full px-3 py-1 text-sm font-medium {session.status === 'preparing'
+										? 'bg-yellow-100 text-yellow-600'
+										: session.status === 'individual'
+											? 'bg-blue-100 text-blue-600'
+											: session.status === 'before-group'
+												? 'bg-purple-100 text-purple-600'
+												: session.status === 'group'
+													? 'bg-green-100 text-green-600'
+													: 'bg-gray-100 text-gray-600'}"
+								>
+									{session.status}
+								</span>
+							</div>
 							<div class="mb-4 flex min-h-[28px] flex-wrap gap-2">
 								{#if session.labels?.length}
 									{#each session.labels.sort() as label}
@@ -340,7 +355,6 @@
 								{/if}
 							</div>
 							<p class="mb-4 line-clamp-2 text-gray-600">{session.task}</p>
-							<p class="mb-4 line-clamp-2 text-blue-600">Now is in {session.status} stage.</p>
 							<div class="mb-4 flex items-center gap-4">
 								<span class="text-sm text-gray-500">
 									{(session.createdAt as Timestamp).toDate().toLocaleString()}
@@ -375,9 +389,23 @@
 				{#each $sessions as [hoster, docid, session]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 line-clamp-1 text-xl font-bold">{session.title}</h3>
+							<div class="mb-4 flex items-start justify-between">
+								<h3 class="line-clamp-1 text-xl font-bold">{session.title}</h3>
+								<span
+									class="rounded-full px-3 py-1 text-sm font-medium {session.status === 'preparing'
+										? 'bg-yellow-100 text-yellow-600'
+										: session.status === 'individual'
+											? 'bg-blue-100 text-blue-600'
+											: session.status === 'before-group'
+												? 'bg-purple-100 text-purple-600'
+												: session.status === 'group'
+													? 'bg-green-100 text-green-600'
+													: 'bg-gray-100 text-gray-600'}"
+								>
+									{session.status}
+								</span>
+							</div>
 							<p class="mb-4 line-clamp-2 text-gray-600">{session.task}</p>
-							<p class="mb-4 line-clamp-2 text-blue-600">Now is in {session.status} stage.</p>
 							<p class="line-clamp-2 text-gray-500">Host by: {hoster}</p>
 							<div class="mb-4 flex items-center gap-4">
 								<span class="text-sm text-gray-500">

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -212,7 +212,7 @@
 				{#each $publicTemplates as [doc, template]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 text-xl font-bold">{template.title}</h3>
+							<h3 class="mb-2 line-clamp-1 text-xl font-bold">{template.title}</h3>
 							<p class="mb-4 line-clamp-2 text-gray-600">{template.task}</p>
 							<div class="mb-4 flex items-center gap-4">
 								<span class="text-sm text-gray-500">
@@ -268,7 +268,7 @@
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
 							<div class="mb-4 flex items-start justify-between">
-								<h3 class="text-xl font-bold">{template.title}</h3>
+								<h3 class="line-clamp-1 text-xl font-bold">{template.title}</h3>
 								<span
 									class="rounded-full px-3 py-1 text-sm font-medium {template.public
 										? 'bg-green-100 text-green-600'
@@ -329,7 +329,7 @@
 				{#each $filteredHostSessions as [doc, session]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 text-xl font-bold">{session.title}</h3>
+							<h3 class="mb-2 line-clamp-1 text-xl font-bold">{session.title}</h3>
 							<div class="mb-4 flex min-h-[28px] flex-wrap gap-2">
 								{#if session.labels?.length}
 									{#each session.labels.sort() as label}
@@ -375,7 +375,7 @@
 				{#each $sessions as [hoster, docid, session]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 text-xl font-bold">{session.title}</h3>
+							<h3 class="mb-2 line-clamp-1 text-xl font-bold">{session.title}</h3>
 							<p class="mb-4 line-clamp-2 text-gray-600">{session.task}</p>
 							<p class="mb-4 line-clamp-2 text-blue-600">Now is in {session.status} stage.</p>
 							<p class="line-clamp-2 text-gray-500">Host by: {hoster}</p>

--- a/src/routes/dashboard/recent/host/+page.svelte
+++ b/src/routes/dashboard/recent/host/+page.svelte
@@ -91,7 +91,22 @@
 				{#each $filteredHostSessions as [doc, session]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 text-xl font-bold">{session.title}</h3>
+							<div class="mb-4 flex items-start justify-between">
+								<h3 class="line-clamp-1 text-xl font-bold">{session.title}</h3>
+								<span
+									class="rounded-full px-3 py-1 text-sm font-medium {session.status === 'preparing'
+										? 'bg-yellow-100 text-yellow-600'
+										: session.status === 'individual'
+											? 'bg-blue-100 text-blue-600'
+											: session.status === 'before-group'
+												? 'bg-purple-100 text-purple-600'
+												: session.status === 'group'
+													? 'bg-green-100 text-green-600'
+													: 'bg-gray-100 text-gray-600'}"
+								>
+									{session.status}
+								</span>
+							</div>
 							<div class="mb-4 flex min-h-[28px] flex-wrap gap-2">
 								{#if session.labels?.length}
 									{#each session.labels.sort() as label}
@@ -102,7 +117,6 @@
 								{/if}
 							</div>
 							<p class="mb-4 line-clamp-2 text-gray-600">{session.task}</p>
-							<p class="mb-4 line-clamp-2 text-blue-600">Now is in {session.status} stage.</p>
 							<div class="mb-4 flex items-center gap-4">
 								<span class="text-sm text-gray-500">
 									{(session.createdAt as Timestamp).toDate().toLocaleString()}

--- a/src/routes/dashboard/recent/participant/+page.svelte
+++ b/src/routes/dashboard/recent/participant/+page.svelte
@@ -78,9 +78,32 @@
 				{#each $sessions as [hoster, docid, session]}
 					<Card padding="lg" class="transition-all hover:border-primary-500">
 						<div>
-							<h3 class="mb-2 text-xl font-bold">{session.title}</h3>
+							<div class="mb-4 flex items-start justify-between">
+								<h3 class="line-clamp-1 text-xl font-bold">{session.title}</h3>
+								<span
+									class="rounded-full px-3 py-1 text-sm font-medium {session.status === 'preparing'
+										? 'bg-yellow-100 text-yellow-600'
+										: session.status === 'individual'
+											? 'bg-blue-100 text-blue-600'
+											: session.status === 'before-group'
+												? 'bg-purple-100 text-purple-600'
+												: session.status === 'group'
+													? 'bg-green-100 text-green-600'
+													: 'bg-gray-100 text-gray-600'}"
+								>
+									{session.status}
+								</span>
+							</div>
+							<div class="mb-4 flex min-h-[28px] flex-wrap gap-2">
+								{#if session.labels?.length}
+									{#each session.labels.sort() as label}
+										<span class="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+											{label}
+										</span>
+									{/each}
+								{/if}
+							</div>
 							<p class="mb-4 line-clamp-2 text-gray-600">{session.task}</p>
-							<p class="mb-4 line-clamp-2 text-blue-600">Now is in {session.status} stage.</p>
 							<p class="line-clamp-2 text-gray-500">Host by: {hoster}</p>
 							<div class="mb-4 flex items-center gap-4">
 								<span class="text-sm text-gray-500">

--- a/src/routes/template/[id]/+page.svelte
+++ b/src/routes/template/[id]/+page.svelte
@@ -135,13 +135,7 @@
 		<form on:submit|preventDefault={saveTemplate} class="space-y-6">
 			<div>
 				<label for="title" class="mb-2 block">Title</label>
-				<Input
-					id="title"
-					bind:value={title}
-					required
-					maxlength={200}
-					placeholder="Template title"
-				/>
+				<Input id="title" bind:value={title} required maxlength={50} placeholder="Template title" />
 			</div>
 
 			<div>


### PR DESCRIPTION
This pull request includes several changes aimed at improving the user interface and user experience across multiple components and pages. The primary focus is on enhancing the layout and readability of session and template titles, as well as improving the visual representation of session statuses.

Improvements to session and template title layout:

* [`src/lib/components/session/HostView.svelte`](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL486-R486): Refactored the layout to use a more flexible column-based structure for better alignment and spacing of session titles and labels. [[1]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL486-R486) [[2]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fL500-R501) [[3]](diffhunk://#diff-0c3dc447ca6aa7d6aa43b5d504989e13fc71f341d2db088bd3c9e6924034bf1fR511)
* [`src/routes/dashboard/+page.svelte`](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L215-R215): Added `line-clamp-1` class to session and template titles to ensure they are displayed in a single line, improving readability. [[1]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L215-R215) [[2]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L271-R271) [[3]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L332-R347) [[4]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L378-L380)

Enhancements to session status representation:

* [`src/routes/dashboard/+page.svelte`](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L332-R347): Introduced color-coded badges for different session statuses, making it easier to distinguish between session stages at a glance. [[1]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L332-R347) [[2]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L378-L380)
* [`src/routes/dashboard/recent/host/+page.svelte`](diffhunk://#diff-488bac84c3b32b69f13dda2b6dea94254e08a68c7f7b2246c1c06df1bb61dcecL94-R109): Added color-coded badges for session statuses and removed redundant status text. [[1]](diffhunk://#diff-488bac84c3b32b69f13dda2b6dea94254e08a68c7f7b2246c1c06df1bb61dcecL94-R109) [[2]](diffhunk://#diff-488bac84c3b32b69f13dda2b6dea94254e08a68c7f7b2246c1c06df1bb61dcecL105)
* [`src/routes/dashboard/recent/participant/+page.svelte`](diffhunk://#diff-b43c5747036319347edcb1742eac78c53d5f7e47f253cabca5750ef5ed470745L81-L83): Implemented color-coded badges for session statuses and included label display for better session identification.

Other changes:

* `src/routes/template/[id]/+page.svelte`: Simplified the `Input` component for the template title by consolidating attributes into a single line for better readability. ([src/routes/template/[id]/+page.svelteL138-R138](diffhunk://#diff-e307aca68c54d08af897f33b2c097e57a9c2548828f5d333d6a86b2f9b45c189L138-R138))