### PR TITLE
fix: remove qr scan error notification

### DIFF
--- a/src/lib/components/QrScanner.svelte
+++ b/src/lib/components/QrScanner.svelte
@@ -39,7 +39,7 @@
 					if ((err as unknown as Error).toString().includes('NotFoundException')) {
 						return;
 					}
-					notifications.error(`error during scanning: ${err}`);
+					// notifications.error(`error during scanning: ${err}`);
 				}
 			);
 		} catch (err) {


### PR DESCRIPTION
This pull request includes a small change to the `QrScanner.svelte` file. The change comments out the line that displays an error notification during scanning.

* [`src/lib/components/QrScanner.svelte`](diffhunk://#diff-fd74a6040d19e4f4a209076e95cfdf92374226f28377f2539e3989215d22127cL42-R42): Commented out the line that displays an error notification during scanning.