### PR TITLE
feat: add @google/generative-ai dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@ffmpeg/ffmpeg": "^0.12.12",
 		"@ffmpeg/util": "^0.12.1",
 		"@genkit-ai/googleai": "^0.9.12",
+		"@google/generative-ai": "^0.21.0",
 		"@hinagiku/ffmpeg-core": "0.12.6-pcm-mpeg-only",
 		"@ricky0123/vad-web": "^0.0.22",
 		"@sveltejs/adapter-auto": "^3.3.1",
@@ -83,8 +84,5 @@
 			"eslint --fix"
 		]
 	},
-	"packageManager": "pnpm@9.15.1",
-	"dependencies": {
-		"@google/generative-ai": "^0.21.0"
-	}
+	"packageManager": "pnpm@9.15.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,6 @@ settings:
 
 importers:
   .:
-    dependencies:
-      '@google/generative-ai':
-        specifier: ^0.21.0
-        version: 0.21.0
     devDependencies:
       '@aws-sdk/client-s3':
         specifier: ^3.717.0
@@ -23,6 +19,9 @@ importers:
       '@genkit-ai/googleai':
         specifier: ^0.9.12
         version: 0.9.12(encoding@0.1.13)(genkit@0.9.12)
+      '@google/generative-ai':
+        specifier: ^0.21.0
+        version: 0.21.0
       '@hinagiku/ffmpeg-core':
         specifier: 0.12.6-pcm-mpeg-only
         version: 0.12.6-pcm-mpeg-only


### PR DESCRIPTION
This pull request includes updates to dependencies in the `package.json` and `pnpm-lock.yaml` files. The most important changes involve the addition and removal of the `@google/generative-ai` dependency.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27): Added `@google/generative-ai` version `^0.21.0` to the dependencies.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L86-R87): Removed `@google/generative-ai` from the dependencies section and adjusted the package manager configuration.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9-L12): Removed `@google/generative-ai` from the dependencies section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR22-R24): Added `@google/generative-ai` version `0.21.0` to the importers section.