### PR TITLE
Add GCP support for object storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ HUGGINGFACE_TOKEN="hf_xxx"
 LLAMA_CLOUD_API_KEY="llx-xxx"
 
 GOOGLE_GENAI_API_KEY="XXX"
+
+GCP_PROJECT_ID="your-gcp-project-id"
+GCP_BUCKET_NAME="your-gcp-bucket-name"
+GCP_KEY_FILENAME="path-to-your-gcp-keyfile.json"

--- a/src/lib/server/object-storage.ts
+++ b/src/lib/server/object-storage.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/private';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import rfc2047 from 'rfc2047';
 import { v4 as uuidv4 } from 'uuid';
+import { Storage } from '@google-cloud/storage';
 
 const CLOUDFLARE_ACCOUNT_ID = env.CLOUDFLARE_ACCOUNT_ID;
 const CLOUDFLARE_R2_BUCKET = env.CLOUDFLARE_R2_BUCKET;
@@ -18,6 +19,12 @@ const client = new S3Client({
 		secretAccessKey: env.CLOUDFLARE_R2_SECRET_ACCESS_KEY
 	}
 });
+
+const storage = new Storage({
+	projectId: env.GCP_PROJECT_ID,
+	keyFilename: env.GCP_KEY_FILENAME
+});
+const bucket = storage.bucket(env.GCP_BUCKET_NAME);
 
 const EXT = {
 	'audio/wav': 'wav',
@@ -49,6 +56,10 @@ export async function upload_object(
 		metadata[k] = rfc2047.encode(v);
 	}
 
+	if (env.USE_GCP === 'true') {
+		return upload_object_gcp(object, type, metadata);
+	}
+
 	const command = new PutObjectCommand({
 		Bucket: CLOUDFLARE_R2_BUCKET,
 		Key: key,
@@ -61,4 +72,39 @@ export async function upload_object(
 	const url = `${CLOUDFLARE_R2_PUBLIC_URL}/${key}`;
 	console.log(`Uploaded object to ${url}`);
 	return url;
+}
+
+export async function upload_object_gcp(
+	object: Buffer,
+	type: keyof typeof EXT,
+	metadata: Record<string, string> = {}
+): Promise<string> {
+	const ext = EXT[type];
+	if (!ext) {
+		throw new Error('Invalid file type');
+	}
+
+	const key = `${uuidv4()}.${ext}`;
+
+	const file = bucket.file(key);
+	const stream = file.createWriteStream({
+		metadata: {
+			contentType: type,
+			metadata: metadata
+		}
+	});
+
+	return new Promise((resolve, reject) => {
+		stream.on('error', (err) => {
+			reject(err);
+		});
+
+		stream.on('finish', () => {
+			const url = `https://storage.googleapis.com/${env.GCP_BUCKET_NAME}/${key}`;
+			console.log(`Uploaded object to ${url}`);
+			resolve(url);
+		});
+
+		stream.end(object);
+	});
 }

--- a/src/routes/api/stt/+server.ts
+++ b/src/routes/api/stt/+server.ts
@@ -1,6 +1,6 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 
-import { upload_object } from '$lib/server/object-storage';
+import { upload_object, upload_object_gcp } from '$lib/server/object-storage';
 import { transcribe } from '$lib/stt/gemini';
 
 // curl -X POST http://localhost:5173/api/stt -H "Content-Type: multipart/form-data" -H "Origin: http://localhost:5173" -F "file=@test.wav"
@@ -25,7 +25,9 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 
 		const transcription = await transcribe(audio_buffer);
-		const url = await upload_object(audio_buffer, 'audio/mpeg', { transcription });
+		const url = process.env.USE_GCP === 'true'
+			? await upload_object_gcp(audio_buffer, 'audio/mpeg', { transcription })
+			: await upload_object(audio_buffer, 'audio/mpeg', { transcription });
 		return json({ status: 'success', transcription, url });
 	} catch (error) {
 		console.error('Error processing request:', error);


### PR DESCRIPTION
Add GCP support for object storage.

* **GCP Client Initialization**: Initialize GCP client using `@google-cloud/storage` in `src/lib/server/object-storage.ts`.
* **GCP Upload Function**: Create `upload_object_gcp` function to handle GCP object uploads in `src/lib/server/object-storage.ts`.
* **Conditional Upload**: Update `upload_object` function to conditionally use GCP or Cloudflare R2 based on configuration in `src/lib/server/object-storage.ts`.
* **API Route Update**: Update `POST` handler in `src/routes/api/stt/+server.ts` to use `upload_object_gcp` if GCP is configured.
* **Environment Variables**: Add GCP-related environment variables (`GCP_PROJECT_ID`, `GCP_BUCKET_NAME`, `GCP_KEY_FILENAME`) to `.env.example`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hinagiku-dev/Hinagiku/pull/140?shareId=2b7a59fc-8929-4482-8bb8-0dd9f1a8b8bc).