### PR TITLE
fix: update permissions for build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pull request includes a small but important change to the GitHub Actions workflow configuration file. The change specifies permissions for the `build-and-push` job.

Permissions update:

* [`.github/workflows/build-and-push.yml`](diffhunk://#diff-ff6530072f2ee96cab1b3a1bd86c4db4afa00ae564f6484789969129711495aeR11-R13): Added `contents: read` and `packages: write` permissions to the `build-and-push` job.