### PR TITLE
feat: language setting layout

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Navbar, NavBrand, Avatar, Dropdown, DropdownItem, Button } from 'flowbite-svelte';
-	import { LogOut, User, Settings, LayoutDashboard } from 'lucide-svelte';
+	import { LogOut, User, Settings, LayoutDashboard, Globe } from 'lucide-svelte';
 	import { signOut, user } from '$lib/stores/auth';
 	import { profile } from '$lib/stores/profile';
 	import { onMount } from 'svelte';
@@ -13,11 +13,9 @@
 
 	import { derived } from 'svelte/store';
 
-	const flagSrc = derived(language, ($language) => {
-		return $language === 'zh' ? '/icons/flag-zh.jpg' : '/icons/flag-us.png';
+	const currentLanguageText = derived(language, ($language) => {
+		return $language === 'zh' ? '繁體中文' : 'English';
 	});
-
-	const fallbackFlagSrc = '/icons/flag-us.png';
 
 	onMount(() => {
 		const interval = setInterval(() => {
@@ -66,6 +64,25 @@
 		</span>
 	</NavBrand>
 	<div class="ml-auto flex items-center">
+		<!-- Language dropdown menu with text and icon -->
+		<Button
+			id="language-menu"
+			class="mr-2 flex items-center gap-1 bg-transparent px-3 hover:bg-gray-100 dark:hover:bg-gray-700"
+		>
+			<Globe class="h-4 w-4 text-gray-500" />
+			<span class="text-gray-500">{hydrated ? $currentLanguageText : 'English'}</span>
+			<span class="ml-1 text-xs text-gray-500">▼</span>
+		</Button>
+		<Dropdown triggeredBy="#language-menu" class="w-36">
+			<DropdownItem class="flex items-center" on:click={() => setLanguage('en')}>
+				<img src="/icons/flag-us.png" alt="English" class="mr-2 h-4 w-4" />
+				English
+			</DropdownItem>
+			<DropdownItem class="flex items-center" on:click={() => setLanguage('zh')}>
+				<img src="/icons/flag-zh.jpg" alt="中文" class="mr-2 h-4 w-4" />
+				繁體中文
+			</DropdownItem>
+		</Dropdown>
 		{#if $user}
 			<Avatar id="user-menu" src={$user.photoURL || ''} alt="User" class="cursor-pointer" />
 			<Dropdown triggeredBy="#user-menu" class="w-48">
@@ -89,23 +106,5 @@
 		{:else if !page.url.pathname.startsWith('/login')}
 			<Button href="/login" class="">{m.login()}</Button>
 		{/if}
-
-		<!-- Remove the old toggle button and add a dropdown for language selection(PM requested) -->
-		<Avatar
-			id="language-menu"
-			src={hydrated ? $flagSrc : fallbackFlagSrc}
-			alt="language"
-			class="ml-2 cursor-pointer"
-		/>
-		<Dropdown triggeredBy="#language-menu" class="w-36">
-			<DropdownItem class="flex items-center" on:click={() => setLanguage('en')}>
-				<img src="/icons/flag-us.png" alt="English" class="mr-2 h-4 w-4" />
-				English
-			</DropdownItem>
-			<DropdownItem class="flex items-center" on:click={() => setLanguage('zh')}>
-				<img src="/icons/flag-zh.jpg" alt="中文" class="mr-2 h-4 w-4" />
-				繁體中文
-			</DropdownItem>
-		</Dropdown>
 	</div>
 </Navbar>

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -34,20 +34,20 @@
 		language.set(lang);
 		console.log('set language to', lang);
 		//console.log('current pathname:', window.location.pathname);
-		if (lang === 'zh' && window.location.pathname.startsWith('/en')) {
-			console.log('gotozh', window.location.pathname.replace('/en', ''));
-			if (window.location.pathname === '/en') {
+		if (lang === 'en' && window.location.pathname.startsWith('/zh')) {
+			console.log('gotoen', window.location.pathname.replace('/zh', ''));
+			if (window.location.pathname === '/zh') {
 				window.location.assign(
-					window.location.pathname.replace('/en', '/') + window.location.search
+					window.location.pathname.replace('/zh', '/') + window.location.search
 				);
 			} else {
 				window.location.assign(
-					window.location.pathname.replace('/en', '') + window.location.search
+					window.location.pathname.replace('/zh', '') + window.location.search
 				);
 			}
-		} else if (lang === 'en' && !window.location.pathname.startsWith('/en')) {
-			console.log('gotoen', window.location.pathname);
-			window.location.assign('/en' + window.location.pathname + window.location.search);
+		} else if (lang === 'zh' && !window.location.pathname.startsWith('/zh')) {
+			console.log('gotozh', window.location.pathname);
+			window.location.assign('/zh' + window.location.pathname + window.location.search);
 		}
 		//window.location.reload();
 	}

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -34,20 +34,20 @@
 		language.set(lang);
 		console.log('set language to', lang);
 		//console.log('current pathname:', window.location.pathname);
-		if (lang === 'en' && window.location.pathname.startsWith('/zh')) {
-			console.log('gotoen', window.location.pathname.replace('/zh', ''));
-			if (window.location.pathname === '/zh') {
+		if (lang === 'zh' && window.location.pathname.startsWith('/en')) {
+			console.log('gotozh', window.location.pathname.replace('/en', ''));
+			if (window.location.pathname === '/en') {
 				window.location.assign(
-					window.location.pathname.replace('/zh', '/') + window.location.search
+					window.location.pathname.replace('/en', '/') + window.location.search
 				);
 			} else {
 				window.location.assign(
-					window.location.pathname.replace('/zh', '') + window.location.search
+					window.location.pathname.replace('/en', '') + window.location.search
 				);
 			}
-		} else if (lang === 'zh' && !window.location.pathname.startsWith('/zh')) {
-			console.log('gotozh', window.location.pathname);
-			window.location.assign('/zh' + window.location.pathname + window.location.search);
+		} else if (lang === 'en' && !window.location.pathname.startsWith('/en')) {
+			console.log('gotoen', window.location.pathname);
+			window.location.assign('/en' + window.location.pathname + window.location.search);
 		}
 		//window.location.reload();
 	}

--- a/src/lib/stores/language.ts
+++ b/src/lib/stores/language.ts
@@ -8,7 +8,7 @@ function getSavedLanguage() {
 			return saved;
 		}
 	}
-	return 'zh';
+	return 'en';
 }
 
 export const language = writable<'en' | 'zh'>(getSavedLanguage());

--- a/src/lib/stores/language.ts
+++ b/src/lib/stores/language.ts
@@ -8,7 +8,7 @@ function getSavedLanguage() {
 			return saved;
 		}
 	}
-	return 'en';
+	return 'zh';
 }
 
 export const language = writable<'en' | 'zh'>(getSavedLanguage());


### PR DESCRIPTION
This pull request includes several changes to the `src/lib/components/Navbar.svelte` file and a small modification to the `src/lib/stores/language.ts` file. The main focus of these changes is to enhance the language selection functionality and update the default language setting.

Enhancements to language selection:

* Added the `Globe` icon from `lucide-svelte` to the imports in `Navbar.svelte`.
* Replaced the flag image logic with text representation for the current language in the `Navbar.svelte` file.
* Updated the language switching logic to correctly handle URL path changes for both English and Chinese languages.
* Introduced a new language dropdown menu with text and icon in the `Navbar.svelte` file, replacing the old toggle button. [[1]](diffhunk://#diff-1d2ad6a3da75a887eb8578849e9baec3e174d19671b9b281a5d2413995235fc1R67-R85) [[2]](diffhunk://#diff-1d2ad6a3da75a887eb8578849e9baec3e174d19671b9b281a5d2413995235fc1L92-L109)

Default language setting:

* Changed the default language from 'en' to 'zh' in the `getSavedLanguage` function in `language.ts`.