### PR TITLE
fix: summary by filter off-topic message from history message list

### DIFF
--- a/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/summary/+server.ts
+++ b/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/summary/+server.ts
@@ -29,7 +29,13 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 			throw error(403, 'Forbidden');
 		}
 
-		const response = await summarizeStudentChat(history);
+		// Loop and filter the list of messages from the history if the message is offTopic
+		const filteredHistory = history.filter((message) => !message.warning?.offTopic);
+		if (filteredHistory.length === 0) {
+			return new Response(JSON.stringify({ success: true }), { status: 200 });
+		}
+
+		const response = await summarizeStudentChat(filteredHistory);
 		if (!response.success) {
 			throw error(500, response.error);
 		}

--- a/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/summary/+server.ts
+++ b/src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/summary/+server.ts
@@ -29,10 +29,21 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 			throw error(403, 'Forbidden');
 		}
 
-		// Loop and filter the list of messages from the history if the message is offTopic
-		const filteredHistory = history.filter((message) => !message.warning?.offTopic);
+		// Loop and filter the list of messages from the history if the message is offTopic or the role is assistant
+		const filteredHistory = history.filter(
+			(message) => !message.warning?.offTopic && message.role !== 'assistant'
+		);
 		if (filteredHistory.length === 0) {
+			// If there are no messages to summarize, return a success response
+			console.log('No messages to summarize');
+			await conversation_ref.update({
+				summary: 'No messages to summarize',
+				keyPoints: []
+			});
 			return new Response(JSON.stringify({ success: true }), { status: 200 });
+		} else {
+			console.log('History:', history);
+			console.log('Filtered history:', filteredHistory);
 		}
 
 		const response = await summarizeStudentChat(filteredHistory);


### PR DESCRIPTION
Key change:

* Implemented a filter to exclude off-topic messages from the chat history before generating the summary. If all messages are off-topic, an early response is returned indicating success. ([src/routes/api/session/[id]/group/[group_number]/conversations/[conv_id]/summary/+server.tsL32-R38](diffhunk://#diff-d884b83ebce09102801e2ecb682d2c5b44f002e3ada7fe632d7a5848e4d5124fL32-R38))