### PR TITLE
fix: add GOOGLE_APPLICATION_CREDENTIALS environment variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 ENV SVELTEKIT_ADAPTER=node
+
+ENV GOOGLE_APPLICATION_CREDENTIALS=service-account-file.example.json
+
 RUN pnpm build
 # Replace __dirname with import.meta.dirname in all .js files in /app/build and subdirectories
 RUN find /app/build -type f -name "*.js" -exec sed -i 's/__dirname/import.meta.dirname/g' {} \;


### PR DESCRIPTION
This pull request introduces a small but important change to the `Dockerfile`. It adds an environment variable to specify the location of the Google Cloud service account credentials.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R9-R11): Added the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, pointing to `service-account-file.example.json`, to support Google Cloud authentication.