### PR TITLE
refactor: object storage

### DIFF
--- a/src/lib/server/object-storage.ts
+++ b/src/lib/server/object-storage.ts
@@ -5,24 +5,6 @@ import { getDownloadURL, ref, updateMetadata, uploadBytes } from 'firebase/stora
 import rfc2047 from 'rfc2047';
 import { v4 as uuidv4 } from 'uuid';
 
-const CLOUDFLARE_ACCOUNT_ID = env.CLOUDFLARE_ACCOUNT_ID;
-const CLOUDFLARE_R2_BUCKET = env.CLOUDFLARE_R2_BUCKET;
-const CLOUDFLARE_R2_PUBLIC_URL = env.CLOUDFLARE_R2_PUBLIC_URL;
-if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_R2_BUCKET || !CLOUDFLARE_R2_PUBLIC_URL) {
-	throw new Error('Cloudflare R2 bucket and account ID are required');
-}
-
-const client = new S3Client({
-	region: 'auto',
-	endpoint: `https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-	credentials: {
-		accessKeyId: env.CLOUDFLARE_R2_ACCESS_KEY_ID,
-		secretAccessKey: env.CLOUDFLARE_R2_SECRET_ACCESS_KEY
-	}
-});
-
-const STORAGE_USE_FIREBASE = env.STORAGE_USE_FIREBASE;
-
 const EXT = {
 	'audio/wav': 'wav',
 	'audio/mpeg': 'mp3',
@@ -37,61 +19,70 @@ const EXT = {
 	'application/json': 'json'
 } as const;
 
+interface StorageAdapter {
+	upload(object: Buffer, type: keyof typeof EXT, metadata: Record<string, string>): Promise<string>;
+}
+
+class CloudflareAdapter implements StorageAdapter {
+	private client: S3Client;
+	private bucket: string;
+	private publicUrl: string;
+	constructor() {
+		const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+		const bucket = env.CLOUDFLARE_R2_BUCKET;
+		const publicUrl = env.CLOUDFLARE_R2_PUBLIC_URL;
+		if (!accountId || !bucket || !publicUrl) {
+			throw new Error('Cloudflare R2 bucket and account ID are required');
+		}
+		this.bucket = bucket;
+		this.publicUrl = publicUrl;
+		this.client = new S3Client({
+			region: 'auto',
+			endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+			credentials: {
+				accessKeyId: env.CLOUDFLARE_R2_ACCESS_KEY_ID!,
+				secretAccessKey: env.CLOUDFLARE_R2_SECRET_ACCESS_KEY!
+			}
+		});
+	}
+	async upload(object: Buffer, type: keyof typeof EXT, metadata: Record<string, string>) {
+		const ext = EXT[type];
+		const key = `${uuidv4()}.${ext}`;
+		const cmd = new PutObjectCommand({
+			Bucket: this.bucket,
+			Key: key,
+			Body: object,
+			ContentType: type,
+			Metadata: metadata
+		});
+		await this.client.send(cmd);
+		return `${this.publicUrl}/${key}`;
+	}
+}
+
+class FirebaseAdapter implements StorageAdapter {
+	async upload(object: Buffer, type: keyof typeof EXT, metadata: Record<string, string>) {
+		const ext = EXT[type];
+		const key = `${uuidv4()}.${ext}`;
+		const storageRef = ref(storageBucket, key);
+		await uploadBytes(storageRef, object, { contentType: type });
+		await updateMetadata(storageRef, { customMetadata: metadata });
+		return getDownloadURL(storageRef);
+	}
+}
+
+const storageService: StorageAdapter =
+	env.HINAGIKU_STORAGE_BACKEND === 'r2' ? new CloudflareAdapter() : new FirebaseAdapter();
+
 export async function upload_object(
 	object: Buffer,
 	type: keyof typeof EXT,
 	metadata: Record<string, string> = {}
 ): Promise<string> {
-	const ext = EXT[type];
-	if (!ext) {
-		throw new Error('Invalid file type');
-	}
-
-	const key = `${uuidv4()}.${ext}`;
-
 	for (const [k, v] of Object.entries(metadata)) {
 		metadata[k] = rfc2047.encode(v);
 	}
-
-	if (STORAGE_USE_FIREBASE === 'true') {
-		return upload_object_firebase(object, type, metadata);
-	}
-
-	const command = new PutObjectCommand({
-		Bucket: CLOUDFLARE_R2_BUCKET,
-		Key: key,
-		Body: object,
-		ContentType: type,
-		Metadata: metadata
-	});
-	await client.send(command);
-
-	const url = `${CLOUDFLARE_R2_PUBLIC_URL}/${key}`;
+	const url = await storageService.upload(object, type, metadata);
 	console.log(`Uploaded object to ${url}`);
-	return url;
-}
-
-export async function upload_object_firebase(
-	object: Buffer,
-	type: keyof typeof EXT,
-	metadata: Record<string, string> = {}
-): Promise<string> {
-	const ext = EXT[type];
-	if (!ext) {
-		throw new Error('Invalid file type');
-	}
-
-	const key = `${uuidv4()}.${ext}`;
-	const storageRef = ref(storageBucket, key);
-
-	await uploadBytes(storageRef, object, { contentType: type });
-	console.log('File uploaded successfully');
-
-	await updateMetadata(storageRef, { customMetadata: metadata });
-	console.log('Metadata updated successfully');
-
-	const url = await getDownloadURL(storageRef);
-	console.log(`Uploaded object to ${url}`);
-
 	return url;
 }

--- a/src/routes/api/stt/+server.ts
+++ b/src/routes/api/stt/+server.ts
@@ -1,7 +1,7 @@
-import { json, type RequestHandler } from '@sveltejs/kit';
-
-import { upload_object, upload_object_firebase } from '$lib/server/object-storage';
+import { upload_object } from '$lib/server/object-storage';
 import { transcribe } from '$lib/stt/gemini';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
 
 // curl -X POST http://localhost:5173/api/stt -H "Content-Type: multipart/form-data" -H "Origin: http://localhost:5173" -F "file=@test.wav"
 export const POST: RequestHandler = async ({ request }) => {
@@ -25,10 +25,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 
 		const transcription = await transcribe(audio_buffer);
-		const url =
-			process.env.STORAGE_USE_FIREBASE === 'true'
-				? await upload_object_firebase(audio_buffer, 'audio/mpeg', { transcription })
-				: await upload_object(audio_buffer, 'audio/mpeg', { transcription });
+		const url = await upload_object(audio_buffer, 'audio/mpeg', { transcription });
 		return json({ status: 'success', transcription, url });
 	} catch (error) {
 		console.error('Error processing request:', error);


### PR DESCRIPTION
This pull request refactors the object storage implementation to introduce a pluggable storage adapter architecture, supporting both Cloudflare R2 and Firebase backends. It removes hardcoded logic for backend selection and simplifies the API for uploading objects. Additionally, it updates the STT API to utilize the new storage architecture.

### Refactoring for Storage Backend Abstraction:

* Introduced a `StorageAdapter` interface and implemented two concrete classes: `CloudflareAdapter` and `FirebaseAdapter`. These classes encapsulate the logic for their respective storage backends (`src/lib/server/object-storage.ts`).
* Replaced environment variable checks and hardcoded backend logic with a `storageService` instance that dynamically selects the appropriate adapter based on the `HINAGIKU_STORAGE_BACKEND` environment variable (`src/lib/server/object-storage.ts`).

### Simplification of Object Upload API:

* Refactored the `upload_object` function to delegate the actual upload process to the selected storage adapter, ensuring consistent metadata encoding and logging (`src/lib/server/object-storage.ts`).

### Updates to STT API:

* Removed the now-deprecated `upload_object_firebase` function and updated the STT API to use the unified `upload_object` function for uploading audio files (`src/routes/api/stt/+server.ts`).
* Cleaned up imports in the STT API to reflect the removal of the Firebase-specific upload function (`src/routes/api/stt/+server.ts`).