### PR TITLE
fix: update dashboard label for consistency in UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,7 @@
 	"intro": "{title} helps educators facilitate more engaging and productive discussions through real-time transcription and intelligent analysis.",
 	"welcome": "Welcome to {title}!",
 	"profile": "Profile",
-	"dashboard": "Go to Dashboard",
+	"dashboard": "Dashboard",
 	"signOut": "Sign out",
 	"login": "Login",
 	"started": "Get Started",


### PR DESCRIPTION
This pull request includes a minor update to the `messages/en.json` file. The change simplifies the "dashboard" label text by removing the phrase "Go to" and leaving it as just "Dashboard" for consistency and brevity.