### PR TITLE
feat: add VAD status indicator

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -293,5 +293,8 @@
 	"announcementBroadcasted": "Announcement broadcasted successfully",
 	"announcementFailed": "Failed to broadcast announcement",
 	"announcementCancelled": "Announcement cancelled successfully",
-	"announcementCancelFailed": "Failed to cancel announcement"
+	"announcementCancelFailed": "Failed to cancel announcement",
+	"enabled": "Enabled",
+	"disabled": "Disabled",
+	"vad": "VAD"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -294,5 +294,8 @@
 	"announcementBroadcasted": "公告廣播成功",
 	"announcementFailed": "廣播公告失敗",
 	"announcementCancelled": "公告取消成功",
-	"announcementCancelFailed": "取消公告失敗"
+	"announcementCancelFailed": "取消公告失敗",
+	"enabled": "啟用",
+	"disabled": "禁用",
+	"vad": "語音活動檢測"
 }

--- a/src/lib/components/Chatroom.svelte
+++ b/src/lib/components/Chatroom.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button, Card, Textarea } from 'flowbite-svelte';
-	import { Mic, Send, Square } from 'lucide-svelte'; // Added Square icon import
+	import { Mic, Send, Square } from 'lucide-svelte';
 	import AudioPlayer from './AudioPlayer.svelte';
 	import { renderMarkdown } from '$lib/utils/renderMarkdown';
 	import * as m from '$lib/paraglide/messages.js';
@@ -20,7 +20,8 @@
 		conversations,
 		readonly = false,
 		autoscroll = true,
-		isIndividual = false
+		isIndividual = false,
+		vadEnabled = false
 	}: {
 		record?: () => Promise<() => Promise<void>>;
 		send?: (text: string) => Promise<void>;
@@ -28,6 +29,7 @@
 		readonly?: boolean;
 		autoscroll?: boolean;
 		isIndividual?: boolean;
+		vadEnabled?: boolean;
 	} = $props();
 
 	let text = $state('');
@@ -185,29 +187,40 @@
 						{text.length} / 500
 					</div>
 				</div>
-				<div class="ml-auto flex gap-2">
-					<Button
-						color={recording && !operating ? 'red' : 'primary'}
-						class="gap-2"
-						disabled={operating}
-						on:click={handleRecord}
-					>
-						{#if recording && !operating}
-							<Square class="animate-pulse" />
+				<div class="ml-auto flex flex-col">
+					<div class="flex max-h-32 min-h-14 flex-1 gap-2">
+						<Button
+							color={recording && !operating ? 'red' : 'primary'}
+							class="gap-2"
+							disabled={operating}
+							on:click={handleRecord}
+						>
+							{#if recording && !operating}
+								<Square class="animate-pulse" />
+							{:else}
+								<Mic />
+							{/if}
+							{recording ? (operating ? m.waiting() : m.stop()) : m.record()}
+						</Button>
+						<Button
+							color="primary"
+							class="gap-2"
+							disabled={operating || !text.trim()}
+							on:click={handleSend}
+						>
+							<Send class={operating ? 'animate-pulse' : ''} />
+							{m.send()}
+						</Button>
+					</div>
+
+					<div class="text-right text-sm text-gray-500">
+						{m.vad()}
+						{#if vadEnabled}
+							{m.enabled()}
 						{:else}
-							<Mic />
+							{m.disabled()}
 						{/if}
-						{recording ? (operating ? m.waiting() : m.stop()) : m.record()}
-					</Button>
-					<Button
-						color="primary"
-						class="gap-2"
-						disabled={operating || !text.trim()}
-						on:click={handleSend}
-					>
-						<Send class={operating ? 'animate-pulse' : ''} />
-						{m.send()}
-					</Button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/session/ParticipantView.svelte
+++ b/src/lib/components/session/ParticipantView.svelte
@@ -55,6 +55,9 @@
 
 	let waitlistjoined = $state(false);
 	let isGroupManagementEnabled = $state(false);
+	let vadEnabled = $derived(
+		$session?.status === 'individual' ? $setting?.enableVADIndividual : $setting?.enableVADGroup
+	);
 	$effect(() => {
 		if ($session?.settings?.autoGroup) {
 			isGroupManagementEnabled = false;
@@ -802,7 +805,13 @@
 					<p class="text-gray-600">{m.hostBeginShortly()}</p>
 				</div>
 			{:else if $session?.status === 'individual'}
-				<Chatroom record={handleRecord} send={handleSend} {conversations} isIndividual />
+				<Chatroom
+					record={handleRecord}
+					send={handleSend}
+					{conversations}
+					{vadEnabled}
+					isIndividual
+				/>
 			{:else if $session?.status === 'before-group'}
 				<div class="space-y-6">
 					{#if groupDoc && conversationDoc}
@@ -819,6 +828,7 @@
 						conversations={groupDiscussions}
 						record={handleGroupRecord}
 						send={handleGroupSend}
+						{vadEnabled}
 					/>
 				{:else if groupStatus === 'summarize' || loadingGroupSummary}
 					<div class="space-y-6">


### PR DESCRIPTION
internal tracker id: N-001

This pull request introduces a new feature to support Voice Activity Detection (VAD) in the chatroom and participant view components, along with associated UI updates and localization changes. The most important changes include adding a `vadEnabled` property to components, updating the UI to display VAD status, and adding translations for VAD-related terms.

### Feature: Voice Activity Detection (VAD) Support

* [`src/lib/components/Chatroom.svelte`](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdL23-R32): Added a new `vadEnabled` property to the component's props and updated the UI to display the VAD status (enabled/disabled) dynamically. [[1]](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdL23-R32) [[2]](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdR215-R224)
* [`src/lib/components/session/ParticipantView.svelte`](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R58-R60): Integrated the `vadEnabled` property into both individual and group chatroom sessions, with logic to derive its value based on session settings. [[1]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R58-R60) [[2]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96L805-R814) [[3]](diffhunk://#diff-476a3db584a448488a3a1ac20e53027b048ac557d6928a0041b5af3b33901f96R831)

### UI Enhancements

* [`src/lib/components/Chatroom.svelte`](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdL188-R191): Modified the layout of the chatroom's action buttons to use a vertical column structure, improving visual clarity.

### Localization Updates

* `messages/en.json` and `messages/zh.json`: Added new translations for "Enabled," "Disabled," and "VAD" to support the VAD feature in multiple languages. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL296-R299) [[2]](diffhunk://#diff-b1da422c0458d9d7093c9418675ac11a7d276d2d366636a493cca8e90dd75912L297-R300)