### PR TITLE
feat: add stop recording reminders for VAD and non-VAD scenarios in C…

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -301,5 +301,7 @@
 	"groupVocabulary": "Group",
 	"recentHostActivity": "Recent Host Activity",
 	"createYourFirstTemplate": "Create your first template to get started",
-	"endAfterGroupStage": "End After Group Stage"
+	"endAfterGroupStage": "End After Group Stage",
+	"stopRecordingReminderWithoutVAD": "Remember to press the stop button after speaking!",
+	"stopRecordingReminderWithVAD": "Feel free to speak until the discussion ends :D"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -302,5 +302,7 @@
 	"endAfterGroupStage": "結束小組討論總結階段",
 	"groupVocabulary": "組別",
 	"recentHostActivity": "最近主持的活動",
-	"createYourFirstTemplate": "創建您的第一個模板以開始"
+	"createYourFirstTemplate": "創建您的第一個模板以開始",
+	"stopRecordingReminderWithoutVAD": "講完話之後，記得按下停止鍵喔！",
+	"stopRecordingReminderWithVAD": "請自由自在的發言，直到討論結束：D"
 }

--- a/src/lib/components/Chatroom.svelte
+++ b/src/lib/components/Chatroom.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button, Card, Textarea } from 'flowbite-svelte';
+	import { Button, Card, Textarea, Tooltip } from 'flowbite-svelte';
 	import { Mic, Send, Square } from 'lucide-svelte';
 	import AudioPlayer from './AudioPlayer.svelte';
 	import { renderMarkdown } from '$lib/utils/renderMarkdown';
@@ -202,6 +202,15 @@
 							{/if}
 							{recording ? (operating ? m.waiting() : m.stop()) : m.record()}
 						</Button>
+						{#if recording}
+							<Tooltip trigger="focus" open={true}>
+								{#if vadEnabled}
+									{m.stopRecordingReminderWithVAD()}
+								{:else}
+									{m.stopRecordingReminderWithoutVAD()}
+								{/if}
+							</Tooltip>
+						{/if}
 						<Button
 							color="primary"
 							class="gap-2"
@@ -211,15 +220,6 @@
 							<Send class={operating ? 'animate-pulse' : ''} />
 							{m.send()}
 						</Button>
-					</div>
-
-					<div class="text-right text-sm text-gray-500">
-						{m.vad()}
-						{#if vadEnabled}
-							{m.enabled()}
-						{:else}
-							{m.disabled()}
-						{/if}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This pull request introduces a new feature to display tooltips with reminders during voice recording in the chatroom component and includes supporting updates to localization files. Additionally, it removes redundant UI elements related to VAD (Voice Activity Detection) status. Below are the key changes:

### New Feature: Recording Reminder Tooltips
* Added new tooltip functionality in `Chatroom.svelte` to display reminders while recording: one for when VAD is enabled and another for when it is not. These tooltips appear automatically when recording starts. (`src/lib/components/Chatroom.svelte`, [src/lib/components/Chatroom.svelteR205-R213](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdR205-R213))
* Imported the `Tooltip` component from `flowbite-svelte` to support the new feature. (`src/lib/components/Chatroom.svelte`, [src/lib/components/Chatroom.svelteL2-R2](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdL2-R2))

### Localization Updates
* Added two new localized strings, `stopRecordingReminderWithoutVAD` and `stopRecordingReminderWithVAD`, in `messages/en.json` and `messages/zh.json` to support the tooltips in English and Chinese. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL304-R306) [[2]](diffhunk://#diff-b1da422c0458d9d7093c9418675ac11a7d276d2d366636a493cca8e90dd75912L305-R307)

### UI Simplification
* Removed the VAD status text from the chatroom UI, streamlining the interface by eliminating redundant information. (`src/lib/components/Chatroom.svelte`, [src/lib/components/Chatroom.svelteL215-L223](diffhunk://#diff-31a2070f41fdaa274729f68d27df9e502cdb6c29abe9e0525b095d68de81cacdL215-L223))…hatroom component