### PR TITLE
feat: refactor LLM integration to use unified llmModel across components

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"flowbite": "^2.5.2",
 		"flowbite-svelte": "^0.47.4",
 		"genkit": "^0.9.12",
+		"genkitx-openai": "^0.22.3",
 		"globals": "^15.15.0",
 		"html5-qrcode": "^2.3.8",
 		"husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       genkit:
         specifier: ^0.9.12
         version: 0.9.12
+      genkitx-openai:
+        specifier: ^0.22.3
+        version: 0.22.3(encoding@0.1.13)(genkit@0.9.12)(zod@3.24.2)
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -5034,6 +5037,14 @@ packages:
         integrity: sha512-m1VQE/yhuii0y1aGTnkoSesSXTNE25q1s7vv5YVgJWa/t2gOXuznZOoHTJ847f/3mKC7fgnV7xGI+t/+7wbe0g==
       }
 
+  genkitx-openai@0.22.3:
+    resolution:
+      {
+        integrity: sha512-g+4I2QOHfBcHz6R9N/z5mqXsMNc7+jtF258jwBOi1X5YuJ7hFIpbTxF8QktfUdH8w440t7s7Upa0aZRw+JhfsA==
+      }
+    peerDependencies:
+      genkit: ^0.9.0 || ^1.0.0
+
   get-caller-file@2.0.5:
     resolution:
       {
@@ -6179,6 +6190,21 @@ packages:
     resolution:
       {
         integrity: sha512-nvYeFjmjdSu6/msld+22JoUlCICNk/lUFpSMmc6KNhpeNLpqL70TqbD/8Vura/tFmYqHKW0trcjgPwUpKSPwaA==
+      }
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@4.97.0:
+    resolution:
+      {
+        integrity: sha512-LRoiy0zvEf819ZUEJhgfV8PfsE8G5WpQi4AwA1uCV8SKvvtXQkoWUFkepD6plqyJQRghy2+AEPQ07FrJFKHZ9Q==
       }
     hasBin: true
     peerDependencies:
@@ -11499,6 +11525,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  genkitx-openai@0.22.3(encoding@0.1.13)(genkit@0.9.12)(zod@3.24.2):
+    dependencies:
+      genkit: 0.9.12
+      openai: 4.97.0(encoding@0.1.13)(zod@3.24.2)
+    transitivePeerDependencies:
+      - encoding
+      - ws
+      - zod
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
@@ -12115,6 +12150,20 @@ snapshots:
       platform: 1.3.6
 
   openai@4.86.2(encoding@0.1.13)(zod@3.24.2):
+    dependencies:
+      '@types/node': 18.19.76
+      '@types/node-fetch': 2.6.12
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+    optionalDependencies:
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - encoding
+
+  openai@4.97.0(encoding@0.1.13)(zod@3.24.2):
     dependencies:
       '@types/node': 18.19.76
       '@types/node-fetch': 2.6.12

--- a/scripts/chatLLM.ts
+++ b/scripts/chatLLM.ts
@@ -1,22 +1,23 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
 import { genkit } from 'genkit';
+import { gpt41Mini, openAI } from 'genkitx-openai';
 import { z } from 'zod';
 import { HARMFUL_CONTENT_DETECTION_PROMPT } from '../src/lib/server/prompt';
 import type { LLMChatMessage } from '../src/lib/server/types';
 
-export const GoogleGeminiFlash = genkit({
-	plugins: [googleAI({ apiKey: process.env.GOOGLE_GENAI_API_KEY })],
-	model: gemini15Flash
+export const llmModel = genkit({
+	plugins: [openAI({ apiKey: process.env.OPENAI_API_KEY })],
+	model: gpt41Mini
 });
+
 export async function requestLLM(
 	history: LLMChatMessage[],
 	schema: z.ZodSchema,
 	system_prompt?: string
 ) {
-	const { output } = await GoogleGeminiFlash.generate({
+	const { output } = await llmModel.generate({
 		prompt: [
 			...(system_prompt ? [{ text: system_prompt }] : []),
 			...history.map((msg) => ({
@@ -68,6 +69,26 @@ async function isHarmfulContent(content: string) {
 async function main() {
 	const result = await isHarmfulContent('你好');
 	console.log(result);
+	const response = await requestLLM(
+		[
+			{
+				role: 'user' as const,
+				content: '請幫我寫一個簡單的Python程式，讓我可以計算圓的面積'
+			},
+			{
+				role: 'assistant' as const,
+				content:
+					'當然可以！這是一個簡單的Python程式，可以計算圓的面積：\n\n```python\nimport math\n\ndef calculate_circle_area(radius):\n    return math.pi * radius ** 2\n\nradius = float(input("請輸入圓的半徑："))\narea = calculate_circle_area(radius)\nprint(f"圓的面積是：{area}")\n```'
+			}
+		],
+		z.object({
+			code: z.string(),
+			'code-language': z.string(),
+			'code-explanation': z.string()
+		}),
+		'請幫我檢查這段程式碼的錯誤，並給我建議'
+	);
+	console.log('Response:', response);
 }
 
 main();

--- a/src/lib/ai/google.ts
+++ b/src/lib/ai/google.ts
@@ -1,8 +1,13 @@
 import { env } from '$env/dynamic/private';
 import { genkit } from 'genkit';
-import { gpt41Mini, openAI } from 'genkitx-openai';
+import { gpt41Mini, gpt4oTranscribe, openAI } from 'genkitx-openai';
 
 export const llmModel = genkit({
 	plugins: [openAI({ apiKey: env.OPENAI_API_KEY })],
 	model: gpt41Mini
+});
+
+export const asrModel = genkit({
+	plugins: [openAI({ apiKey: env.OPENAI_API_KEY })],
+	model: gpt4oTranscribe
 });

--- a/src/lib/ai/google.ts
+++ b/src/lib/ai/google.ts
@@ -1,13 +1,8 @@
 import { env } from '$env/dynamic/private';
+import { gemini15Flash, googleAI } from '@genkit-ai/googleai';
 import { genkit } from 'genkit';
-import { gpt41Mini, gpt4oTranscribe, openAI } from 'genkitx-openai';
 
-export const llmModel = genkit({
-	plugins: [openAI({ apiKey: env.OPENAI_API_KEY })],
-	model: gpt41Mini
-});
-
-export const asrModel = genkit({
-	plugins: [openAI({ apiKey: env.OPENAI_API_KEY })],
-	model: gpt4oTranscribe
+export const GoogleGeminiFlash = genkit({
+	plugins: [googleAI({ apiKey: env.GOOGLE_GENAI_API_KEY })],
+	model: gemini15Flash
 });

--- a/src/lib/ai/google.ts
+++ b/src/lib/ai/google.ts
@@ -1,8 +1,8 @@
 import { env } from '$env/dynamic/private';
-import { gemini20Flash, googleAI } from '@genkit-ai/googleai';
 import { genkit } from 'genkit';
+import { gpt41Mini, openAI } from 'genkitx-openai';
 
-export const GoogleGeminiFlash = genkit({
-	plugins: [googleAI({ apiKey: env.GOOGLE_GENAI_API_KEY })],
-	model: gemini20Flash
+export const llmModel = genkit({
+	plugins: [openAI({ apiKey: env.OPENAI_API_KEY })],
+	model: gpt41Mini
 });

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -1,2 +1,9 @@
+import { GoogleGeminiFlash } from './google';
+import { OpenAIGpt41Mini } from './openai';
+
 export { z } from 'zod';
 export * from './google';
+export * from './openai';
+
+export const llmModel = OpenAIGpt41Mini;
+export const asrModel = GoogleGeminiFlash;

--- a/src/lib/ai/openai.ts
+++ b/src/lib/ai/openai.ts
@@ -1,0 +1,8 @@
+import { env } from '$env/dynamic/private';
+import { genkit } from 'genkit';
+import { gpt41Mini, openAI } from 'genkitx-openai';
+
+export const OpenAIGpt41Mini = genkit({
+	plugins: [openAI({ apiKey: env.OPENAI_API_KEY })],
+	model: gpt41Mini
+});

--- a/src/lib/server/gemini.ts
+++ b/src/lib/server/gemini.ts
@@ -1,4 +1,4 @@
-import { GoogleGeminiFlash, z } from '$lib/ai';
+import { llmModel, z } from '$lib/ai';
 import type { Resource } from '$lib/schema/resource';
 import type { Discussion, LLMChatMessage } from '$lib/server/types';
 import {
@@ -25,7 +25,7 @@ export async function requestLLM(
 	topP: number = 0.5
 ) {
 	try {
-		const { output } = await GoogleGeminiFlash.generate({
+		const { output } = await llmModel.generate({
 			system: system_prompt,
 			prompt: HISTORY_PROMPT.replace(
 				'{chatHistory}',

--- a/src/lib/server/pdf.ts
+++ b/src/lib/server/pdf.ts
@@ -1,5 +1,5 @@
 // import pdf from 'pdf-parse';
-import { GoogleGeminiFlash, z } from '$lib/ai';
+import { llmModel, z } from '$lib/ai';
 import { PDF_PARSE_PROMPT } from './prompt';
 
 // export async function pdf2Text(fileBuffer: ArrayBuffer, apiKey: string): Promise<string | null> {
@@ -15,7 +15,7 @@ import { PDF_PARSE_PROMPT } from './prompt';
 
 export async function pdf2Text(fileBuffer: ArrayBuffer): Promise<string | null> {
 	try {
-		const { output } = await GoogleGeminiFlash.generate({
+		const { output } = await llmModel.generate({
 			system: PDF_PARSE_PROMPT,
 			prompt: [
 				{

--- a/src/lib/stt/gemini.ts
+++ b/src/lib/stt/gemini.ts
@@ -1,8 +1,8 @@
-import { GoogleGeminiFlash, z } from '$lib/ai';
+import { llmModel, z } from '$lib/ai';
 
 export async function transcribe(data: Buffer): Promise<string> {
 	const dataurl = `data:audio/wav;base64,${data.toString('base64')}`;
-	const { output } = await GoogleGeminiFlash.generate({
+	const { output } = await llmModel.generate({
 		system: '(zh-tw)請將語音確實轉錄，使用的主要語言為臺灣繁體中文，次要語言為英語。',
 		prompt: [{ text: '' }, { media: { url: dataurl } }],
 		output: {

--- a/src/lib/stt/gemini.ts
+++ b/src/lib/stt/gemini.ts
@@ -1,8 +1,8 @@
-import { llmModel, z } from '$lib/ai';
+import { asrModel, z } from '$lib/ai';
 
 export async function transcribe(data: Buffer): Promise<string> {
 	const dataurl = `data:audio/wav;base64,${data.toString('base64')}`;
-	const { output } = await llmModel.generate({
+	const { output } = await asrModel.generate({
 		system: '(zh-tw)請將語音確實轉錄，使用的主要語言為臺灣繁體中文，次要語言為英語。',
 		prompt: [{ text: '' }, { media: { url: dataurl } }],
 		output: {


### PR DESCRIPTION
This pull request replaces the Google Gemini Flash model with OpenAI's GPT-4.1 Mini model across multiple files in the codebase. The changes involve updating imports, modifying the LLM model initialization, and ensuring all references to the previous model are updated to use the new one.

### Transition from Google Gemini Flash to OpenAI GPT-4.1 Mini:

* **Model Initialization Updates**:
  - Replaced the `GoogleGeminiFlash` model with `llmModel` using OpenAI's GPT-4.1 Mini in `scripts/chatLLM.ts` and `src/lib/ai/google.ts`. Updated the plugin configuration to use OpenAI's API key. [[1]](diffhunk://#diff-4095838e699db8b9d3c80fd2d77efcabe8cb8477f068f48809c7b4535f67adf5L4-R20) [[2]](diffhunk://#diff-69ec65897a11dc7e8bb02d0cac5d8b2dab73155031f859579e67744cdbf920b6L2-R7)

* **Function Updates**:
  - Updated all references to `GoogleGeminiFlash.generate` to `llmModel.generate` in the following files:
    - `scripts/chatLLM.ts` [[1]](diffhunk://#diff-4095838e699db8b9d3c80fd2d77efcabe8cb8477f068f48809c7b4535f67adf5L4-R20) [[2]](diffhunk://#diff-4095838e699db8b9d3c80fd2d77efcabe8cb8477f068f48809c7b4535f67adf5R72-R91)
    - `src/lib/server/gemini.ts`
    - `src/lib/server/pdf.ts`
    - `src/lib/stt/gemini.ts`

* **Import Adjustments**:
  - Replaced imports of `GoogleGeminiFlash` with `llmModel` in various files to reflect the new model. [[1]](diffhunk://#diff-c2a6f86757120491865be9bb731662dcbcc014587ed8f79e2bdd099906a86d7bL1-R1) [[2]](diffhunk://#diff-6a0cecd97eaff63564e64820892cd7ae0c505b52e183abfafcd82359a97bbdc4L2-R2) [[3]](diffhunk://#diff-c035fe9c12f9ba047a3fd1f2642b4da6ed8dafb7194012fb20bf31c08db4260aL1-R5)

* **New Example Usage**:
  - Added a new example in `scripts/chatLLM.ts` demonstrating the use of `requestLLM` to process a Python code snippet and provide suggestions.