### PR TITLE
fix : chatroom x-axis overflow issue

### DIFF
--- a/src/lib/components/Chatroom.svelte
+++ b/src/lib/components/Chatroom.svelte
@@ -235,4 +235,9 @@
 		padding: 0;
 		overflow: hidden;
 	}
+	.prose {
+		max-width: fit-content;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+	}
 </style>


### PR DESCRIPTION
This pull request fixes part of #203 .
Below screenshots shows the different of original chatroom and the chatroom after css modification.

![image](https://github.com/user-attachments/assets/7794341d-c39f-4c53-a24b-e7aeb4170d81)
![image](https://github.com/user-attachments/assets/6083567e-f4f0-4373-9244-71e9b99419f8)
