### PR TITLE
Add labels to templates

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -303,5 +303,14 @@
 	"createYourFirstTemplate": "Create your first template to get started",
 	"endAfterGroupStage": "End After Group Stage",
 	"stopRecordingReminderWithoutVAD": "Remember to press the stop button after speaking!",
-	"stopRecordingReminderWithVAD": "Feel free to speak until the discussion ends :D"
+	"stopRecordingReminderWithVAD": "Feel free to speak until the discussion ends :D",
+	"label": "Label",
+	"labels": "Labels",
+	"addLabel": "Add label",
+	"labelAdded": "Label added successfully",
+	"labelAddFailed": "Failed to add label",
+	"labelRemoved": "Label removed successfully",
+	"labelRemoveFailed": "Failed to remove label",
+	"tag": "Tag",
+	"tags": "Tags"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -304,5 +304,14 @@
 	"recentHostActivity": "最近主持的活動",
 	"createYourFirstTemplate": "創建您的第一個模板以開始",
 	"stopRecordingReminderWithoutVAD": "講完話之後，記得按下停止鍵喔！",
-	"stopRecordingReminderWithVAD": "請自由自在的發言，直到討論結束：D"
+	"stopRecordingReminderWithVAD": "請自由自在的發言，直到討論結束：D",
+	"label": "標籤",
+	"labels": "標籤",
+	"addLabel": "新增標籤",
+	"labelAdded": "標籤新增成功",
+	"labelAddFailed": "新增標籤失敗",
+	"labelRemoved": "標籤移除成功",
+	"labelRemoveFailed": "移除標籤失敗",
+	"tag": "標籤",
+	"tags": "標籤"
 }

--- a/src/lib/components/TemplateCard.svelte
+++ b/src/lib/components/TemplateCard.svelte
@@ -61,8 +61,8 @@
 
 <Card padding="lg" class="transition-all hover:border-primary-500">
 	<div class="flex h-full flex-col">
-		<div class="mb-4 flex items-start justify-between">
-			<h3 class="line-clamp-1 text-xl font-bold">{title}</h3>
+		<div class="mb-2 flex items-start justify-between">
+			<h3 class="line-clamp-1 flex-1 text-xl font-bold">{title}</h3>
 			{#if isPublic !== undefined}
 				<span
 					class="rounded-full px-3 py-1 text-sm font-medium {isPublic

--- a/src/lib/components/TemplateCard.svelte
+++ b/src/lib/components/TemplateCard.svelte
@@ -14,7 +14,8 @@
 		subtaskSize,
 		resourceSize,
 		owner,
-		isPublic
+		isPublic,
+		labels
 	}: {
 		id: string;
 		title: string;
@@ -23,6 +24,7 @@
 		resourceSize: number;
 		owner: string;
 		isPublic?: boolean;
+		labels?: string[];
 	} = $props();
 
 	let forking = $state(false);
@@ -71,6 +73,15 @@
 				</span>
 			{/if}
 		</div>
+		{#if labels?.length}
+			<div class="mb-2 flex flex-wrap gap-1">
+				{#each labels as label}
+					<span class="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+						{label}
+					</span>
+				{/each}
+			</div>
+		{/if}
 		<p class="mb-4 line-clamp-2 text-gray-600">{task}</p>
 		<div class="mt-auto w-full">
 			<div class="mb-4 flex items-center gap-4">

--- a/src/lib/components/template/LabelManager.svelte
+++ b/src/lib/components/template/LabelManager.svelte
@@ -3,6 +3,7 @@
 	import { Plus, X } from 'lucide-svelte';
 	import { notifications } from '$lib/stores/notifications';
 	import { onMount } from 'svelte';
+	import * as m from '$lib/paraglide/messages';
 
 	let { templateId, labels } = $props<{
 		templateId: string;
@@ -12,7 +13,7 @@
 	let showInput = $state(false);
 	let newLabel = $state('');
 	let inputRef = $state<HTMLDivElement | null>(null);
-	const MAX_LABEL_LENGTH = 20;
+	const MAX_LABEL_LENGTH = 10;
 
 	onMount(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -30,7 +31,12 @@
 		if (!newLabel.trim()) return;
 
 		if (newLabel.length > MAX_LABEL_LENGTH) {
-			notifications.error(`Label must be ${MAX_LABEL_LENGTH} characters or less`);
+			notifications.error(
+				m.characterCount({
+					current: newLabel.length.toString(),
+					limit: MAX_LABEL_LENGTH.toString()
+				})
+			);
 			return;
 		}
 
@@ -48,9 +54,9 @@
 
 			newLabel = '';
 			showInput = false;
-			notifications.success('Label added successfully');
+			notifications.success(m.labelAdded());
 		} catch {
-			notifications.error('Failed to add labels');
+			notifications.error(m.labelAddFailed());
 		}
 	}
 
@@ -58,7 +64,12 @@
 		const input = event.target as HTMLInputElement;
 		if (input.value.length > MAX_LABEL_LENGTH) {
 			input.value = input.value.slice(0, MAX_LABEL_LENGTH);
-			notifications.warning(`Label cannot exceed ${MAX_LABEL_LENGTH} characters`);
+			notifications.warning(
+				m.characterCount({
+					current: input.value.length.toString(),
+					limit: MAX_LABEL_LENGTH.toString()
+				})
+			);
 		}
 		newLabel = input.value;
 	}
@@ -76,9 +87,9 @@
 
 			if (!response.ok) throw new Error('Failed to update labels');
 
-			notifications.success('Label removed successfully');
+			notifications.success(m.labelRemoved());
 		} catch {
-			notifications.error('Failed to remove label');
+			notifications.error(m.labelRemoveFailed());
 		}
 	}
 </script>
@@ -99,7 +110,7 @@
 				on:input={handleInput}
 				size="sm"
 				class="h-8"
-				placeholder="New label"
+				placeholder={m.addLabel()}
 				on:keydown={(e) => {
 					if (e.key === 'Enter') {
 						e.preventDefault();
@@ -125,5 +136,5 @@
 	>
 		<Plus class="h-4 w-4" />
 	</Button>
-	<Tooltip placement="right">Add label</Tooltip>
+	<Tooltip placement="right">{m.addLabel()}</Tooltip>
 </div>

--- a/src/lib/components/template/LabelManager.svelte
+++ b/src/lib/components/template/LabelManager.svelte
@@ -12,7 +12,7 @@
 	let showInput = $state(false);
 	let newLabel = $state('');
 	let inputRef = $state<HTMLDivElement | null>(null);
-	const MAX_LABEL_LENGTH = 10;
+	const MAX_LABEL_LENGTH = 20;
 
 	onMount(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -46,7 +46,6 @@
 
 			if (!response.ok) throw new Error('Failed to update labels');
 
-			labels = updatedLabels;
 			newLabel = '';
 			showInput = false;
 			notifications.success('Label added successfully');
@@ -77,7 +76,6 @@
 
 			if (!response.ok) throw new Error('Failed to update labels');
 
-			labels = updatedLabels;
 			notifications.success('Label removed successfully');
 		} catch {
 			notifications.error('Failed to remove label');
@@ -102,7 +100,12 @@
 				size="sm"
 				class="h-8"
 				placeholder="New label"
-				on:keydown={(e) => e.key === 'Enter' && addLabel()}
+				on:keydown={(e) => {
+					if (e.key === 'Enter') {
+						e.preventDefault();
+						addLabel();
+					}
+				}}
 			/>
 		</div>
 	{/if}

--- a/src/lib/components/template/LabelManager.svelte
+++ b/src/lib/components/template/LabelManager.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { Button, Input, Tooltip } from 'flowbite-svelte';
+	import { Plus, X } from 'lucide-svelte';
+	import { notifications } from '$lib/stores/notifications';
+	import { onMount } from 'svelte';
+
+	let { templateId, labels } = $props<{
+		templateId: string;
+		labels: string[];
+	}>();
+
+	let showInput = $state(false);
+	let newLabel = $state('');
+	let inputRef = $state<HTMLDivElement | null>(null);
+	const MAX_LABEL_LENGTH = 10;
+
+	onMount(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (showInput && inputRef && !inputRef.contains(event.target as Node)) {
+				showInput = false;
+				newLabel = '';
+			}
+		};
+
+		document.addEventListener('click', handleClickOutside);
+		return () => document.removeEventListener('click', handleClickOutside);
+	});
+
+	async function addLabel() {
+		if (!newLabel.trim()) return;
+
+		if (newLabel.length > MAX_LABEL_LENGTH) {
+			notifications.error(`Label must be ${MAX_LABEL_LENGTH} characters or less`);
+			return;
+		}
+
+		const updatedLabels = [...labels, newLabel.trim()];
+		try {
+			const response = await fetch(`/api/template/${templateId}/label`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ labels: updatedLabels })
+			});
+
+			if (!response.ok) throw new Error('Failed to update labels');
+
+			labels = updatedLabels;
+			newLabel = '';
+			showInput = false;
+			notifications.success('Label added successfully');
+		} catch {
+			notifications.error('Failed to add labels');
+		}
+	}
+
+	function handleInput(event: Event) {
+		const input = event.target as HTMLInputElement;
+		if (input.value.length > MAX_LABEL_LENGTH) {
+			input.value = input.value.slice(0, MAX_LABEL_LENGTH);
+			notifications.warning(`Label cannot exceed ${MAX_LABEL_LENGTH} characters`);
+		}
+		newLabel = input.value;
+	}
+
+	async function removeLabel(label: string) {
+		const updatedLabels = labels.filter((l: string) => l !== label);
+		try {
+			const response = await fetch(`/api/template/${templateId}/label`, {
+				method: 'PUT',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ labels: updatedLabels })
+			});
+
+			if (!response.ok) throw new Error('Failed to update labels');
+
+			labels = updatedLabels;
+			notifications.success('Label removed successfully');
+		} catch {
+			notifications.error('Failed to remove label');
+		}
+	}
+</script>
+
+<div class="flex items-center gap-2">
+	{#each labels as label}
+		<div class="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
+			<span class="text-sm">{label}</span>
+			<button class="text-gray-500 hover:text-gray-700" onclick={() => removeLabel(label)}>
+				<X size={14} />
+			</button>
+		</div>
+	{/each}
+	{#if showInput}
+		<div class="flex w-40 items-center gap-1" bind:this={inputRef}>
+			<Input
+				value={newLabel}
+				on:input={handleInput}
+				size="sm"
+				class="h-8"
+				placeholder="New label"
+				on:keydown={(e) => e.key === 'Enter' && addLabel()}
+			/>
+		</div>
+	{/if}
+	<Button
+		size="xs"
+		color="alternative"
+		class="h-8 w-8 rounded-full p-0"
+		on:click={(e) => {
+			e.stopPropagation();
+			if (!showInput) {
+				showInput = true;
+				newLabel = '';
+			} else {
+				addLabel();
+			}
+		}}
+	>
+		<Plus class="h-4 w-4" />
+	</Button>
+	<Tooltip placement="right">Add label</Tooltip>
+</div>

--- a/src/lib/schema/template.ts
+++ b/src/lib/schema/template.ts
@@ -8,6 +8,7 @@ export const TemplateSchema = z.object({
 	title: z.string().min(1).max(200),
 	owner: z.string(),
 	public: z.boolean(),
+	labels: z.array(z.string()).optional().default([]),
 	resources: z.array(ResourceSchema).max(10),
 	task: z.string().min(1).max(200),
 	subtasks: z.array(z.string().min(1).max(200)).max(10),

--- a/src/routes/api/template/+server.ts
+++ b/src/routes/api/template/+server.ts
@@ -22,6 +22,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			],
 			public: data.public ?? false,
 			owner: locals.user.uid,
+			labels: [],
 			resources: [],
 			backgroundImage: null,
 			createdAt: Timestamp.now(),

--- a/src/routes/api/template/[id]/label/+server.ts
+++ b/src/routes/api/template/[id]/label/+server.ts
@@ -1,0 +1,47 @@
+import { adminDb } from '$lib/server/firebase';
+import { error, json } from '@sveltejs/kit';
+import { z } from 'zod';
+import type { RequestHandler } from './$types';
+
+const requestDataFormat = z.object({
+	labels: z.array(z.string())
+});
+
+export const PUT: RequestHandler = async ({ params, request, locals }) => {
+	try {
+		if (!locals.user) {
+			return json({ error: 'Unauthorized' }, { status: 401 });
+		}
+		const { id } = params;
+		if (!id) {
+			return json({ error: 'Missing parameters' }, { status: 400 });
+		}
+
+		const templateRef = adminDb.collection('templates').doc(id);
+		const templateSnap = await templateRef.get();
+		if (!templateSnap.exists) {
+			return json({ error: 'Template not found' }, { status: 404 });
+		}
+		const templateData = templateSnap.data();
+		if (templateData?.owner !== locals.user.uid) {
+			return json({ error: 'Unauthorized' }, { status: 401 });
+		}
+
+		const { labels } = await getRequestData(request);
+		await templateRef.update({ labels });
+
+		return json({ success: true }, { status: 200 });
+	} catch (err) {
+		console.error('Error updating template labels:', err);
+		return json({ error: 'Error updating template labels' }, { status: 500 });
+	}
+};
+
+async function getRequestData(request: Request): Promise<z.infer<typeof requestDataFormat>> {
+	const data = await request.json();
+	const result = requestDataFormat.parse(data);
+	if (!result.labels) {
+		throw error(400, 'Missing parameters');
+	}
+	return result;
+}

--- a/src/routes/api/template/[id]/label/+server.ts
+++ b/src/routes/api/template/[id]/label/+server.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import type { RequestHandler } from './$types';
 
 const requestDataFormat = z.object({
-	labels: z.array(z.string())
+	labels: z.array(z.string()).max(10)
 });
 
 export const PUT: RequestHandler = async ({ params, request, locals }) => {
@@ -28,7 +28,8 @@ export const PUT: RequestHandler = async ({ params, request, locals }) => {
 		}
 
 		const { labels } = await getRequestData(request);
-		await templateRef.update({ labels });
+		labels.sort();
+		await templateRef.update({ labels: [...new Set(labels)] });
 
 		return json({ success: true }, { status: 200 });
 	} catch (err) {

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -213,6 +213,7 @@
 						subtaskSize={template.subtasks.length}
 						resourceSize={template.resources.length}
 						owner={template.owner}
+						labels={template.labels}
 					/>
 				{/each}
 			{:else}
@@ -251,6 +252,7 @@
 						resourceSize={template.resources.length}
 						owner={template.owner}
 						isPublic={template.public}
+						labels={template.labels}
 					/>
 				{/each}
 			{:else}

--- a/src/routes/template/[id]/+page.svelte
+++ b/src/routes/template/[id]/+page.svelte
@@ -285,7 +285,7 @@
 			</div>
 
 			<div>
-				<p class="mb-4 font-medium">Tags</p>
+				<p class="mb-4 font-medium">{m.tags()}</p>
 				<TemplateLabelManager templateId={$page.params.id} {labels} />
 			</div>
 

--- a/src/routes/template/[id]/+page.svelte
+++ b/src/routes/template/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/stores';
 	import type { Template } from '$lib/schema/template';
 	import ResourceList from './ResourceList.svelte';
+	import TemplateLabelManager from '$lib/components/template/LabelManager.svelte';
 	import { onDestroy } from 'svelte';
 	import { doc } from 'firebase/firestore';
 	import { db } from '$lib/firebase';
@@ -17,6 +18,7 @@
 	let title = '';
 	let task = '';
 	let isPublic = false;
+	let labels: string[] = [];
 	let subtasks: string[] = [];
 	let showDeleteModal = false;
 	let isUploading = false;
@@ -34,6 +36,7 @@
 			task = t.task;
 			isPublic = t.public;
 			subtasks = [...t.subtasks];
+			labels = t.labels ? [...t.labels] : [];
 			backgroundPreview = t.backgroundImage || null;
 		}
 	});
@@ -135,6 +138,7 @@
 					task: task.trim(),
 					public: isPublic,
 					subtasks: subtasks.filter((subtask) => subtask.trim()),
+					labels,
 					backgroundImage: backgroundPreview
 				})
 			});
@@ -278,6 +282,11 @@
 					<Plus class="mr-2 h-4 w-4" />
 					{m.addSubtask()}
 				</Button>
+			</div>
+
+			<div>
+				<p class="mb-4 font-medium">Tags</p>
+				<TemplateLabelManager templateId={$page.params.id} {labels} />
 			</div>
 
 			<div class="flex items-center gap-2">

--- a/src/routes/template/[id]/view/+page.svelte
+++ b/src/routes/template/[id]/view/+page.svelte
@@ -29,7 +29,7 @@
 	<!-- Header Section -->
 	<header class="mb-8 border-b border-gray-200 pb-6">
 		<div class="mb-4 flex items-start justify-between">
-			<h1 class="text-4xl font-bold text-gray-900">{template.title}</h1>
+			<h1 class="flex-1 text-4xl font-bold text-gray-900">{template.title}</h1>
 			<Badge color={template.public ? 'green' : 'none'} class="mt-2">
 				{template.public ? m.Tpublic() : m.Tprivate()}
 			</Badge>

--- a/src/routes/templates/+page.svelte
+++ b/src/routes/templates/+page.svelte
@@ -89,6 +89,15 @@
 								{template.public ? m.Tpublic() : m.Tprivate()}
 							</span>
 						</div>
+						{#if template.labels?.length}
+							<div class="mb-2 flex flex-wrap gap-1">
+								{#each template.labels as label}
+									<span class="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+										{label}
+									</span>
+								{/each}
+							</div>
+						{/if}
 						<p class="mb-4 line-clamp-2 text-gray-600">{template.task}</p>
 						<div class="mb-4 flex items-center gap-4">
 							<span class="text-sm text-gray-500">

--- a/src/routes/templates/+page.svelte
+++ b/src/routes/templates/+page.svelte
@@ -2,6 +2,7 @@
 	import { onDestroy } from 'svelte';
 	import { Card, Button } from 'flowbite-svelte';
 	import { MessageSquarePlus } from 'lucide-svelte';
+	import { writable, derived } from 'svelte/store';
 	import { collection, query, where, orderBy } from 'firebase/firestore';
 	import { db } from '$lib/firebase';
 	import { subscribeAll } from '$lib/firebase/store';
@@ -13,6 +14,7 @@
 	import { goto } from '$app/navigation';
 	import { i18n } from '$lib/i18n';
 	import * as m from '$lib/paraglide/messages.js';
+	import TemplateCard from '$lib/components/TemplateCard.svelte';
 	// Query for user's templates
 	let [templates, { unsubscribe }] = subscribeAll<Template>(
 		query(
@@ -21,6 +23,27 @@
 			orderBy('createdAt', 'desc')
 		)
 	);
+
+	let selectedLabels = writable<string[]>([]);
+	let availableLabels = derived(templates, ($templates) => {
+		if (!$templates) return [];
+		const labels = new Set<string>();
+		$templates.forEach(([, t]) => t.labels?.forEach((l) => labels.add(l)));
+		return Array.from(labels).sort();
+	});
+	let filteredTemplates = derived([templates, selectedLabels], ([$templates, $selectedLabels]) => {
+		if (!$templates || $selectedLabels.length === 0) return $templates;
+		return $templates.filter(([, t]) => $selectedLabels.every((l) => t.labels?.includes(l)));
+	});
+
+	function handleLabelSelect(label: string) {
+		selectedLabels.update((ls) => {
+			if (ls.includes(label)) {
+				return ls.filter((l) => l !== label);
+			}
+			return [...ls, label].sort();
+		});
+	}
 
 	onDestroy(() => {
 		unsubscribe();
@@ -34,30 +57,6 @@
 		} catch (error) {
 			console.error('Error creating template:', error);
 			notifications.error('Failed to create template');
-		}
-	}
-
-	async function startSession(id: string) {
-		try {
-			const res = await fetch('/api/session', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					templateId: id
-				})
-			});
-
-			if (!res.ok) {
-				const data = await res.json();
-				notifications.error(data.error || 'Failed to create session');
-				return;
-			}
-
-			const data = await res.json();
-			await goto(i18n.resolveRoute(`/session/${data.sessionId}`));
-		} catch (e) {
-			console.error('Error creating session:', e);
-			notifications.error('Failed to create session');
 		}
 	}
 </script>
@@ -74,47 +73,31 @@
 		</Button>
 	</div>
 
+	<div class="mb-4 flex flex-wrap gap-2">
+		{#each $availableLabels as label}
+			<Button
+				size="xs"
+				color={$selectedLabels.includes(label) ? 'primary' : 'alternative'}
+				on:click={() => handleLabelSelect(label)}
+			>
+				{label}
+			</Button>
+		{/each}
+	</div>
+
 	<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-		{#if $templates?.length}
-			{#each $templates as [doc, template]}
-				<Card padding="lg" class="transition-all hover:border-primary-500">
-					<div>
-						<div class="mb-4 flex items-start justify-between">
-							<h3 class="text-xl font-bold">{template.title}</h3>
-							<span
-								class="rounded-full px-3 py-1 text-sm font-medium {template.public
-									? 'bg-green-100 text-green-600'
-									: 'bg-gray-100 text-gray-600'}"
-							>
-								{template.public ? m.Tpublic() : m.Tprivate()}
-							</span>
-						</div>
-						{#if template.labels?.length}
-							<div class="mb-2 flex flex-wrap gap-1">
-								{#each template.labels as label}
-									<span class="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
-										{label}
-									</span>
-								{/each}
-							</div>
-						{/if}
-						<p class="mb-4 line-clamp-2 text-gray-600">{template.task}</p>
-						<div class="mb-4 flex items-center gap-4">
-							<span class="text-sm text-gray-500">
-								{template.subtasks.length} subtasks
-							</span>
-							<span class="text-sm text-gray-500">
-								{template.resources.length} resources
-							</span>
-						</div>
-						<div class="flex gap-2">
-							<Button href="/template/{doc.id}" class="flex-1">{m.edit()}</Button>
-							<Button onclick={() => startSession(doc.id)} color="alternative" class="flex-1">
-								{m.createSession()}
-							</Button>
-						</div>
-					</div>
-				</Card>
+		{#if $filteredTemplates?.length}
+			{#each $filteredTemplates as [doc, template]}
+				<TemplateCard
+					id={doc.id}
+					title={template.title}
+					task={template.task}
+					subtaskSize={template.subtasks.length}
+					resourceSize={template.resources.length}
+					owner={template.owner}
+					isPublic={template.public}
+					labels={template.labels}
+				/>
 			{/each}
 		{:else}
 			<Card class="md:col-span-2 lg:col-span-3">


### PR DESCRIPTION
## Summary
- allow templates to store `labels`
- expose API to edit template labels
- display labels in template cards
- manage labels from the template editor
- filter public templates by label

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Service account must be an object)*

<img width="1201" alt="截圖 2025-05-21 凌晨3 41 07" src="https://github.com/user-attachments/assets/90b6874a-e8db-4946-9171-27ff9451c3b1" />
<img width="1249" alt="截圖 2025-05-21 凌晨3 41 59" src="https://github.com/user-attachments/assets/dd58bfd3-c570-48ef-90a9-ffa28e7eb0ae" />
<img width="641" alt="截圖 2025-05-21 凌晨3 42 23" src="https://github.com/user-attachments/assets/0f33a855-5979-4c49-8179-07cbd2477b86" />
