### PR TITLE
Fix chat message sanitization

### DIFF
--- a/src/lib/utils/renderMarkdown.ts
+++ b/src/lib/utils/renderMarkdown.ts
@@ -18,5 +18,22 @@ export async function renderMarkdown(markdown: string): Promise<string> {
 	renderer.image = () => '';
 
 	const dirty = await marked(markdown, { renderer });
-	return DOMPurify.sanitize(dirty);
+	return DOMPurify.sanitize(dirty, {
+		ALLOWED_TAGS: [
+			'b',
+			'i',
+			'em',
+			'strong',
+			'code',
+			'pre',
+			'p',
+			'blockquote',
+			'ul',
+			'ol',
+			'li',
+			'br',
+			'a'
+		],
+		ALLOWED_ATTR: ['href', 'title']
+	});
 }


### PR DESCRIPTION
## Summary
- restrict allowable tags and attributes when sanitizing rendered markdown to prevent embedding videos or scripts

## Testing
- `pnpm test` *(fails: Service account must be an object)*