### PR TITLE
refactor: rename llmModel to chatModel and update pdfModel import

### DIFF
--- a/scripts/chatLLM.ts
+++ b/scripts/chatLLM.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { HARMFUL_CONTENT_DETECTION_PROMPT } from '../src/lib/server/prompt';
 import type { LLMChatMessage } from '../src/lib/server/types';
 
-export const llmModel = genkit({
+export const chatModel = genkit({
 	plugins: [openAI({ apiKey: process.env.OPENAI_API_KEY })],
 	model: gpt41Mini
 });
@@ -17,7 +17,7 @@ export async function requestLLM(
 	schema: z.ZodSchema,
 	system_prompt?: string
 ) {
-	const { output } = await llmModel.generate({
+	const { output } = await chatModel.generate({
 		prompt: [
 			...(system_prompt ? [{ text: system_prompt }] : []),
 			...history.map((msg) => ({

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -5,5 +5,6 @@ export { z } from 'zod';
 export * from './google';
 export * from './openai';
 
-export const llmModel = OpenAIGpt41Mini;
+export const chatModel = OpenAIGpt41Mini;
+export const pdfModel = GoogleGeminiFlash;
 export const asrModel = GoogleGeminiFlash;

--- a/src/lib/server/gemini.ts
+++ b/src/lib/server/gemini.ts
@@ -1,4 +1,4 @@
-import { llmModel, z } from '$lib/ai';
+import { chatModel, z } from '$lib/ai';
 import type { Resource } from '$lib/schema/resource';
 import type { Discussion, LLMChatMessage } from '$lib/server/types';
 import {
@@ -27,7 +27,7 @@ export async function requestLLM(
 	topP: number = 0.5
 ) {
 	try {
-		const { output } = await llmModel.generate({
+		const { output } = await chatModel.generate({
 			system: system_prompt,
 			prompt: HISTORY_PROMPT.replace(
 				'{chatHistory}',

--- a/src/lib/server/pdf.ts
+++ b/src/lib/server/pdf.ts
@@ -1,5 +1,5 @@
 // import pdf from 'pdf-parse';
-import { llmModel, z } from '$lib/ai';
+import { pdfModel, z } from '$lib/ai';
 import { PDF_PARSE_PROMPT } from './prompt';
 
 // export async function pdf2Text(fileBuffer: ArrayBuffer, apiKey: string): Promise<string | null> {
@@ -15,7 +15,7 @@ import { PDF_PARSE_PROMPT } from './prompt';
 
 export async function pdf2Text(fileBuffer: ArrayBuffer): Promise<string | null> {
 	try {
-		const { output } = await llmModel.generate({
+		const { output } = await pdfModel.generate({
 			system: PDF_PARSE_PROMPT,
 			prompt: [
 				{


### PR DESCRIPTION
This pull request refactors the naming and usage of AI models across the codebase for better clarity and modularity. The primary focus is on replacing the generic `llmModel` with more specific model names (`chatModel` and `pdfModel`) based on their functionality. This change improves code readability and aligns model naming with their intended use cases.

### Model Renaming and Refactoring:

* Renamed `llmModel` to `chatModel` in `scripts/chatLLM.ts` and updated all references to use the new name. (`[[1]](diffhunk://#diff-4095838e699db8b9d3c80fd2d77efcabe8cb8477f068f48809c7b4535f67adf5L10-R10)`, `[[2]](diffhunk://#diff-4095838e699db8b9d3c80fd2d77efcabe8cb8477f068f48809c7b4535f67adf5L20-R20)`)
* Updated exports in `src/lib/ai/index.ts` to rename `llmModel` to `chatModel` and introduced a new export for `pdfModel` using `GoogleGeminiFlash`. (`[src/lib/ai/index.tsL8-R9](diffhunk://#diff-ff5c33bd69d6c0178a5a94ba2d37e8dba32d3c98d89983fdbca6110e85f345a9L8-R9)`)

### Code Updates for Model Usage:

* Replaced `llmModel` with `chatModel` in `src/lib/server/gemini.ts` for generating responses, ensuring consistency with the new naming convention. (`[[1]](diffhunk://#diff-c2a6f86757120491865be9bb731662dcbcc014587ed8f79e2bdd099906a86d7bL1-R1)`, `[[2]](diffhunk://#diff-c2a6f86757120491865be9bb731662dcbcc014587ed8f79e2bdd099906a86d7bL30-R30)`)
* Updated `src/lib/server/pdf.ts` to use `pdfModel` instead of `llmModel` for PDF parsing tasks, reflecting the specialized role of the model. (`[[1]](diffhunk://#diff-6a0cecd97eaff63564e64820892cd7ae0c505b52e183abfafcd82359a97bbdc4L2-R2)`, `[[2]](diffhunk://#diff-6a0cecd97eaff63564e64820892cd7ae0c505b52e183abfafcd82359a97bbdc4L18-R18)`)