### PR TITLE
Translations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -448,5 +448,6 @@
 	"classGroupEditCancel": "No",
 	"classUpdateGroupSuccess": "group updated successfully",
 	"classUpdateGroupFailed": "failed to update group",
-	"labelLengthLimit": "Label must be {limit} characters or less"
+	"labelLengthLimit": "Label must be {limit} characters or less",
+	"newLabel": "New Label"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -447,5 +447,6 @@
 	"classGroupEditConfirm": "Yes",
 	"classGroupEditCancel": "No",
 	"classUpdateGroupSuccess": "group updated successfully",
-	"classUpdateGroupFailed": "failed to update group"
+	"classUpdateGroupFailed": "failed to update group",
+	"labelLengthLimit": "Label must be {limit} characters or less"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -449,5 +449,16 @@
 	"classGroupEditConfirm": "確定",
 	"classGroupEditCancel": "取消",
 	"classUpdateGroupSuccess": "組別更新成功",
-	"classUpdateGroupFailed": "組別更新失敗"
+	"classUpdateGroupFailed": "組別更新失敗",
+	"editClassInformation": "編輯班級資訊",
+	"updateClassFailed": "更新班級失敗",
+	"updateClassSuccess": "班級更新成功",
+	"deleteClassFailed": "刪除班級失敗",
+	"deleteClassSuccess": "班級刪除成功",
+	"confirmDeleteClass": "確認刪除班級",
+	"confirmDeleteClassTitle": "您確定要刪除這個班級嗎？",
+	"confirmDeleteClassMessage": "您即將刪除班級",
+	"confirmDeleteClassWarning": "。此操作無法撤銷，所有相關的討論和學生資料將被永久刪除。",
+	"confirmDelete": "確認刪除",
+	"deleteClass": "刪除班級"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -322,6 +322,7 @@
 	"labelAddFailed": "新增標籤失敗",
 	"labelRemoved": "標籤移除成功",
 	"labelRemoveFailed": "移除標籤失敗",
+	"labelLengthLimit": "標籤長度不能超過 {limit} 個字元",
 	"tag": "標籤",
 	"tags": "標籤",
 	"saveTemplateSuccess": "模板保存成功",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -461,5 +461,6 @@
 	"confirmDeleteClassMessage": "您即將刪除班級",
 	"confirmDeleteClassWarning": "。此操作無法撤銷，所有相關的討論和學生資料將被永久刪除。",
 	"confirmDelete": "確認刪除",
-	"deleteClass": "刪除班級"
+	"deleteClass": "刪除班級",
+	"newLabel": "新標籤"
 }

--- a/src/lib/components/session/GroupStatus.svelte
+++ b/src/lib/components/session/GroupStatus.svelte
@@ -23,9 +23,13 @@
 					return m.statusIdle({ seconds: diffInSeconds });
 				}
 			}
-			return 'discussion';
+			return m.statusDiscussion();
 		}
-		return group.status || 'waiting';
+		return group.status === 'summarize'
+			? m.statusSummarize()
+			: group.status === 'end'
+				? m.statusEnd()
+				: m.statusWaiting();
 	}
 
 	onMount(() => {
@@ -39,13 +43,13 @@
 
 {#if showStatus}
 	<span
-		class="rounded-full px-2 py-0.5 text-xs {status?.startsWith('idle')
+		class="rounded-full px-2 py-0.5 text-xs {group.status?.startsWith('idle')
 			? 'bg-red-100 text-red-600'
-			: status === 'discussion'
+			: group.status === 'discussion'
 				? 'bg-yellow-100 text-yellow-600'
-				: status === 'summarize'
+				: group.status === 'summarize'
 					? 'bg-blue-100 text-blue-600'
-					: status === 'end'
+					: group.status === 'end'
 						? 'bg-green-100 text-green-600'
 						: 'bg-gray-100 text-gray-600'}"
 	>

--- a/src/lib/components/session/LabelManager.svelte
+++ b/src/lib/components/session/LabelManager.svelte
@@ -3,6 +3,7 @@
 	import { Plus, X } from 'lucide-svelte';
 	import { notifications } from '$lib/stores/notifications';
 	import { onMount } from 'svelte';
+	import * as m from '$lib/paraglide/messages.js';
 
 	let { sessionId, labels } = $props<{
 		sessionId: string;
@@ -30,7 +31,7 @@
 		if (!newLabel.trim()) return;
 
 		if (newLabel.length > MAX_LABEL_LENGTH) {
-			notifications.error(`Label must be ${MAX_LABEL_LENGTH} characters or less`);
+			notifications.error(m.labelLengthLimit({ limit: MAX_LABEL_LENGTH }));
 			return;
 		}
 
@@ -49,9 +50,9 @@
 			labels = updatedLabels;
 			newLabel = '';
 			showInput = false;
-			notifications.success('Label added successfully');
+			notifications.success(m.labelAdded());
 		} catch {
-			notifications.error('Failed to add labels');
+			notifications.error(m.labelAddFailed());
 		}
 	}
 
@@ -59,7 +60,7 @@
 		const input = event.target as HTMLInputElement;
 		if (input.value.length > MAX_LABEL_LENGTH) {
 			input.value = input.value.slice(0, MAX_LABEL_LENGTH);
-			notifications.warning(`Label cannot exceed ${MAX_LABEL_LENGTH} characters`);
+			notifications.warning(m.labelLengthLimit({ limit: MAX_LABEL_LENGTH }));
 		}
 		newLabel = input.value;
 	}
@@ -78,9 +79,9 @@
 			if (!response.ok) throw new Error('Failed to update labels');
 
 			labels = updatedLabels;
-			notifications.success('Label removed successfully');
+			notifications.success(m.labelRemoved());
 		} catch {
-			notifications.error('Failed to remove label');
+			notifications.error(m.labelRemoveFailed());
 		}
 	}
 </script>
@@ -122,5 +123,5 @@
 	>
 		<Plus class="h-4 w-4" />
 	</Button>
-	<Tooltip placement="right">Add label</Tooltip>
+	<Tooltip placement="right">{m.addLabel()}</Tooltip>
 </div>

--- a/src/lib/components/session/LabelManager.svelte
+++ b/src/lib/components/session/LabelManager.svelte
@@ -102,7 +102,7 @@
 				on:input={handleInput}
 				size="sm"
 				class="h-8"
-				placeholder="New label"
+				placeholder={m.newLabel()}
 				on:keydown={(e) => e.key === 'Enter' && addLabel()}
 			/>
 		</div>


### PR DESCRIPTION
This pull request introduces updates to the localization files and refactors several components to improve maintainability and usability. Key changes include adding new localized strings, replacing hardcoded text with dynamic translations, and enhancing the status handling logic in the `GroupStatus` and `LabelManager` components.

### Localization Updates:

* [`messages/en.json`](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL450-R452): Added new strings for label length limits and label creation, improving user feedback consistency.
* [`messages/zh.json`](diffhunk://#diff-b1da422c0458d9d7093c9418675ac11a7d276d2d366636a493cca8e90dd75912R325): Added translations for label-related messages and class management actions, ensuring multilingual support for new features. [[1]](diffhunk://#diff-b1da422c0458d9d7093c9418675ac11a7d276d2d366636a493cca8e90dd75912R325) [[2]](diffhunk://#diff-b1da422c0458d9d7093c9418675ac11a7d276d2d366636a493cca8e90dd75912L452-R465)

### Component Refactoring:

* [`src/lib/components/session/GroupStatus.svelte`](diffhunk://#diff-1ac549872686ed1483781a82bcf4b4603a9045f00df1197de7c6f1734d38e9c6L26-R32): Updated the status handling logic to use message translations for statuses like `discussion`, `summarize`, and `end`, improving code readability and consistency. [[1]](diffhunk://#diff-1ac549872686ed1483781a82bcf4b4603a9045f00df1197de7c6f1734d38e9c6L26-R32) [[2]](diffhunk://#diff-1ac549872686ed1483781a82bcf4b4603a9045f00df1197de7c6f1734d38e9c6L42-R52)
* [`src/lib/components/session/LabelManager.svelte`](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419R6): Replaced hardcoded notifications and placeholders with dynamic translations using the `m` module, ensuring better localization and maintainability. [[1]](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419R6) [[2]](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419L33-R34) [[3]](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419L52-R63) [[4]](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419L81-R84) [[5]](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419L104-R105) [[6]](diffhunk://#diff-12c0df40bc682867f01f6aeb730836b1c5339d34f16cd94f0322e3501a7c7419L125-R126)