### PR TITLE
feat: implement label filtering for participant sessions

### DIFF
--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -82,24 +82,6 @@
 		}
 	);
 
-	function handleLabelSelect(label: string) {
-		selectedLabels.update((labels) => {
-			if (labels.includes(label)) {
-				return labels.filter((l) => l !== label);
-			}
-			return [...labels, label].sort();
-		});
-	}
-
-	let availableLabels = derived(hostSessions, ($hostSessions) => {
-		if (!$hostSessions) return [];
-		const labels = new Set<string>();
-		$hostSessions.forEach(([, session]) => {
-			session.labels?.forEach((label) => labels.add(label));
-		});
-		return Array.from(labels).sort();
-	});
-
 	async function getSessions() {
 		const sessionQuery = query(
 			collectionGroup(db, 'groups'),
@@ -291,17 +273,6 @@
 		<div class="mb-6 flex items-center justify-between">
 			<h2 class="text-2xl font-semibold text-gray-900">{m.recentHostActivity()}</h2>
 			<Button color="alternative" href="/dashboard/recent/host">{m.viewAll()}</Button>
-		</div>
-		<div class="mb-4 flex flex-wrap gap-2">
-			{#each $availableLabels as label}
-				<Button
-					size="xs"
-					color={$selectedLabels.includes(label) ? 'primary' : 'alternative'}
-					on:click={() => handleLabelSelect(label)}
-				>
-					{label}
-				</Button>
-			{/each}
 		</div>
 		<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 			{#if $filteredHostSessions?.length}

--- a/src/routes/dashboard/recent/participant/+page.svelte
+++ b/src/routes/dashboard/recent/participant/+page.svelte
@@ -93,17 +93,19 @@
 	</div>
 
 	<div class="my-8">
-		<div class="mb-4 flex flex-wrap gap-2">
-			{#each $availableLabels as label}
-				<Button
-					size="xs"
-					color={$selectedLabels.includes(label) ? 'primary' : 'alternative'}
-					on:click={() => handleLabelSelect(label)}
-				>
-					{label}
-				</Button>
-			{/each}
-		</div>
+		{#if $availableLabels.length}
+			<div class="mb-4 flex flex-wrap gap-2">
+				{#each $availableLabels as label}
+					<Button
+						size="xs"
+						color={$selectedLabels.includes(label) ? 'primary' : 'alternative'}
+						on:click={() => handleLabelSelect(label)}
+					>
+						{label}
+					</Button>
+				{/each}
+			</div>
+		{/if}
 		<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
 			{#if $filteredSessions.length}
 				{#each $filteredSessions as [id, session]}

--- a/src/routes/dashboard/recent/participant/+page.svelte
+++ b/src/routes/dashboard/recent/participant/+page.svelte
@@ -25,7 +25,7 @@
 	let selectedLabels = writable<string[]>([]);
 
 	let availableLabels = derived(sessions, ($sessions) => {
-		if (!$sessions) return [];
+		if ($sessions.length === 0) return [];
 		const labels = new Set<string>();
 		$sessions.forEach(([, session]) => {
 			session.labels?.forEach((label) => labels.add(label));

--- a/src/routes/dashboard/recent/participant/+page.svelte
+++ b/src/routes/dashboard/recent/participant/+page.svelte
@@ -34,7 +34,7 @@
 	});
 
 	let filteredSessions = derived([sessions, selectedLabels], ([$sessions, $selectedLabels]) => {
-		if (!$sessions || $selectedLabels.length === 0) return $sessions;
+		if ($selectedLabels.length === 0) return $sessions;
 		return $sessions.filter(([, session]) =>
 			$selectedLabels.every((label) => session.labels?.includes(label))
 		);


### PR DESCRIPTION
This pull request refactors label filtering functionality in the dashboard pages. The changes remove the label filtering logic from the host sessions dashboard and reintroduce it in the participant sessions dashboard, improving code organization and aligning functionality with the intended use case.

### Refactoring and Feature Relocation:

* **Host Sessions Dashboard (`src/routes/dashboard/+page.svelte`)**:
  - Removed label filtering logic, including the `handleLabelSelect` function, `availableLabels` derived store, and associated UI elements for label selection. [[1]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L85-L102) [[2]](diffhunk://#diff-7f19569e19f8491f516ab38ba78de121c0018cd2f601fcf4141219e1078a7581L295-L305)

* **Participant Sessions Dashboard (`src/routes/dashboard/recent/participant/+page.svelte`)**:
  - Added label filtering functionality, including:
    - `selectedLabels` writable store and `availableLabels` derived store for managing label selection.
    - `filteredSessions` derived store to filter sessions based on selected labels.
    - `handleLabelSelect` function for updating selected labels.
    - UI elements for label selection integrated into the dashboard layout. [[1]](diffhunk://#diff-b43c5747036319347edcb1742eac78c53d5f7e47f253cabca5750ef5ed470745R25-R51) [[2]](diffhunk://#diff-b43c5747036319347edcb1742eac78c53d5f7e47f253cabca5750ef5ed470745R96-R109)