### PR TITLE
Class code after change password

### DIFF
--- a/src/routes/profile/change-password/+page.svelte
+++ b/src/routes/profile/change-password/+page.svelte
@@ -57,8 +57,9 @@
 				if (classCode) {
 					classCode = classCode.toUpperCase();
 					await goto('/login?classCode=' + classCode);
+				} else {
+					await goto('/login');
 				}
-				await goto('/login');
 			} else {
 				// Handle specific error messages from the API
 				if (response.status === 400 && result.error) {

--- a/src/routes/profile/change-password/+page.svelte
+++ b/src/routes/profile/change-password/+page.svelte
@@ -55,6 +55,7 @@
 				newPassword = '';
 				confirmNewPassword = '';
 				if (classCode) {
+					classCode = classCode.toUpperCase();
 					await goto('/login?classCode=' + classCode);
 				}
 				await goto('/login');

--- a/src/routes/profile/change-password/+page.svelte
+++ b/src/routes/profile/change-password/+page.svelte
@@ -3,13 +3,25 @@
 	import * as m from '$lib/paraglide/messages.js';
 	import Title from '$lib/components/Title.svelte';
 	import { notifications } from '$lib/stores/notifications';
+	import { onMount } from 'svelte';
 	import { user } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { getUser } from '$lib/utils/getUser';
 
 	let currentPassword = '';
 	let newPassword = '';
 	let confirmNewPassword = '';
 	let isLoading = false;
+	let classCode = '';
+
+	onMount(async () => {
+		if ($user) {
+			const profile = await getUser($user.uid);
+			if (profile.studentId) {
+				classCode = $user.email?.split('@')[1].split('.')[0] || '';
+			}
+		}
+	});
 
 	async function handleChangePassword() {
 		if (newPassword !== confirmNewPassword) {
@@ -42,6 +54,9 @@
 				currentPassword = '';
 				newPassword = '';
 				confirmNewPassword = '';
+				if (classCode) {
+					await goto('/login?classCode=' + classCode);
+				}
 				await goto('/login');
 			} else {
 				// Handle specific error messages from the API


### PR DESCRIPTION
This pull request updates the `src/routes/profile/change-password/+page.svelte` file to enhance user experience by introducing logic to handle a `classCode` for navigation and improve user context during the password change process.

### Enhancements to user experience:

* **Added `onMount` logic to retrieve and process `classCode`:** The `onMount` lifecycle function now fetches the user's profile using the `getUser` utility and extracts a `classCode` from the user's email domain if available. (`[src/routes/profile/change-password/+page.svelteR6-R24](diffhunk://#diff-2ed60c2b9a8230da8752f8357bea68163cc9ac7af001e10afc8b908481fa0260R6-R24)`)
* **Updated navigation logic after password change:** If a `classCode` is present, it is converted to uppercase and appended as a query parameter to the `/login` route for improved contextual navigation. (`[src/routes/profile/change-password/+page.svelteR57-R60](diffhunk://#diff-2ed60c2b9a8230da8752f8357bea68163cc9ac7af001e10afc8b908481fa0260R57-R60)`)