### PR TITLE
fix: add baseURL to OpenAI initialization and correct audio file type

### DIFF
--- a/src/lib/stt/openai.ts
+++ b/src/lib/stt/openai.ts
@@ -1,12 +1,12 @@
 import { env } from '$env/dynamic/private';
 import { OpenAI } from 'openai';
 
-const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY, baseURL: 'https://api.openai.com/v1' });
 
 export async function transcribe(data: Buffer): Promise<string> {
 	const transcription = await openai.audio.transcriptions.create({
 		prompt: '請將語音確實轉錄，使用的主要語言為臺灣繁體中文，次要語言為英語。',
-		file: new File([data], 'audio.mp3', { type: 'audio/mp3' }),
+		file: new File([data], 'audio.mp3', { type: 'audio/mpeg' }),
 		model: 'gpt-4o-transcribe'
 	});
 


### PR DESCRIPTION
This pull request makes two updates to the `src/lib/stt/openai.ts` file to enhance the configuration and compatibility of the OpenAI transcription functionality.

Configuration updates:
* Updated the `OpenAI` client initialization to include a `baseURL` parameter, explicitly specifying the API endpoint (`https://api.openai.com/v1`).

Compatibility updates:
* Changed the MIME type of the audio file from `'audio/mp3'` to `'audio/mpeg'` to ensure broader compatibility with audio file standards.